### PR TITLE
Refactor : draft processing classes and bkg method classes

### DIFF
--- a/examples/config_example.yaml
+++ b/examples/config_example.yaml
@@ -1,14 +1,18 @@
 data: 
-    mask: '/media/data/X-ray/Data/MAGIC/WinterSchool2015/Sample1/Crab/MyMelibea/20*.root'
+    mask: '/Users/mstrzys/Documents/Sandbox/Template_bkg_test/20150625/20*.root'
     cuts: '(MHillas_1.fSize>100) & (MHadronness.fHadronness < 0.5) & (MStereoPar.fValid == 1)'
 
-#mode: 'stacked_wobble'
-mode: 'stacked_exclusion'
+# mode: 'stacked_wobble'
+mode: 'runwise_exclusion'
     
 output:
-    directory: 'out/'
+    directory: '/Users/mstrzys/Documents/Sandbox/Template_bkg_test/20150625/'
     prefix: ''
     overwrite: True
+
+run_matching:
+    time_delta: '0.2 hour'
+    pointing_delta: '2 deg'
 
 binning:
     mode: 'rectangular'
@@ -16,15 +20,15 @@ binning:
     x: 
         min: '-1.5 deg'
         max: '1.5 deg'
-        n: 10
+        nbins: 10
     y: 
         min: '-1.5 deg'
         max: '1.5 deg'
-        n: 10
+        nbins: 10
     energy:
         min: '100 GeV'
         max: '10 TeV'
-        n: 1
+        nbins: 1
 
 exclusion_regions:
 #    type: list
@@ -32,4 +36,4 @@ exclusion_regions:
     - 'icrs; circle(83.633080, 22.014500, 0.2d)'
     - 'icrs; circle(83.133080, 22.414500, 0.2d)'
 
-run_matching: {val: 1, unit: 'arcmin'}
+# run_matching: {val: 1, unit: 'arcmin'}

--- a/src/pybkgmodel/data.py
+++ b/src/pybkgmodel/data.py
@@ -11,7 +11,7 @@ from astropy.coordinates import SkyCoord, EarthLocation, AltAz
 
 def find_run_neighbours(target_run, run_list, time_delta, pointing_delta):
     """
-    Returns the nieghbours of the specified run.
+    Returns the neighbours of the specified run.
 
     Parameters
     ----------
@@ -42,7 +42,7 @@ def find_run_neighbours(target_run, run_list, time_delta, pointing_delta):
 
 class EventSample:
     def __init__(
-            self, 
+            self,
             event_ra, event_dec, event_energy,
             pointing_ra, pointing_dec, pointing_az, pointing_zd,
             mjd, delta_t
@@ -57,51 +57,51 @@ class EventSample:
         self.__mjd = mjd
         self.__delta_t = delta_t
         self.__eff_obs_time = self.calc_eff_obs_time()
-    
+
     @property
     def delta_t(self):
         return self.__delta_t
-        
+
     @property
     def eff_obs_time(self):
         return self.__eff_obs_time
-    
+
     @property
     def event_ra(self):
         return self.__event_ra
-    
+
     @property
     def event_dec(self):
         return self.__event_dec
-    
+
     @property
     def event_energy(self):
         return self.__event_energy
-    
+
     @property
     def pointing_ra(self):
         return self.__pointing_ra
-    
+
     @property
     def pointing_dec(self):
         return self.__pointing_dec
-    
+
     @property
     def pointing_az(self):
         return self.__pointing_az
-    
+
     @property
     def pointing_zd(self):
         return self.__pointing_zd
-    
+
     @property
     def pointing_alt(self):
         return 90 * u.deg - self.pointing_zd
-    
+
     @property
     def mjd(self):
         return self.__mjd
-    
+
     def calc_eff_obs_time(self):
         mjd_sorted = numpy.sort(self.__mjd)
         time_diff = numpy.diff(mjd_sorted)
@@ -214,7 +214,7 @@ class MagicEventFile(EventFile):
             obs_id = int(parsed[0])
         else:
             raise RuntimeError(f'Can not find observations ID in {file_name}')
-        
+
         return obs_id
 
     @classmethod
@@ -295,7 +295,7 @@ class MagicEventFile(EventFile):
                 for key in data_names_mapping:
                     name = data_names_mapping[key]
                     event_data[name] = data[key]
-                    
+
                 event_data['gammaness'] = 1 - data['MHadronness.fHadronness']
 
                 is_mc = 'MMcEvt_1.' in input_file['Events']
@@ -331,10 +331,10 @@ class MagicEventFile(EventFile):
                     name = data_names_mapping[key]
                     event_data[name] = numpy.zeros(0)
                 event_data['mjd'] = numpy.zeros(0)
-                    
+
         finite = [numpy.isfinite(event_data[key]) for key in event_data]
         all_finite = numpy.prod(finite, axis=0, dtype=bool)
-        
+
         for key in event_data:
             event_data[key] = event_data[key][all_finite]
 
@@ -377,9 +377,9 @@ class LstEventFile(EventFile):
             obs_id = int(parsed[0])
         else:
             raise RuntimeError(f'Can not find observations ID in {file_name}')
-        
+
         return obs_id
-    
+
     @classmethod
     def load_events(cls, file_name, cuts):
         """
@@ -477,17 +477,17 @@ class LstEventFile(EventFile):
             for key in data_names_mapping:
                 name = data_names_mapping[key]
                 event_data[name] = numpy.zeros(0)
-                   
+
         finite = [numpy.isfinite(event_data[key]) for key in event_data if event_data[key] is not None]
         all_finite = numpy.prod(finite, axis=0, dtype=bool)
 
         for key in event_data:
             if event_data[key] is not None:
                 event_data[key] = event_data[key][all_finite]
-                    
+
                 if key in data_units:
                     event_data[key] = event_data[key] * data_units[key]
-        
+
         event_sample = EventSample(
             event_data['event_ra'],
             event_data['event_dec'],
@@ -516,7 +516,7 @@ class RunSummary:
             events = LstEventFile(file_name)
         else:
             raise RuntimeError(f"Unsupported file format for '{file_name}'.")
-    
+
         if len(events.mjd) != 0:
             evt_selection = [events.mjd.argmin(), events.mjd.argmax()]
             time = astropy.time.Time(events.mjd[evt_selection], format='mjd')
@@ -530,7 +530,7 @@ class RunSummary:
             self.__obs_id = events.obs_id
             self.__tel_pointing_start = pstart
             self.__tel_pointing_stop = pstop
-    
+
     def __repr__(self):
         print(
 f"""{type(self).__name__} instance

--- a/src/pybkgmodel/model.py
+++ b/src/pybkgmodel/model.py
@@ -9,8 +9,72 @@ from pybkgmodel.data import RunSummary, find_run_neighbours
 
 from pybkgmodel.camera import RectangularCameraImage
 
-class _WobbleMap:
+class BaseMap:
+    
+    def __init__(self):
+        pass
+
+    def get_runwise_bkg(self):
+        pass
+
+    def check_data_format(self, target_run, neighbours):
+        if MagicEventFile.is_compatible(target_run.file_name):
+                evtfiles = [
+                    MagicEventFile(run.file_name, cuts=self.cuts)
+                    for run in (target_run,) + neighbours
+                ]
+                return evtfiles
+        elif LstEventFile.is_compatible(target_run.file_name):
+                evtfiles = [
+                    LstEventFile(run.file_name, cuts=self.cuts)
+                    for run in (target_run,) + neighbours
+                ]
+                return evtfiles
+        else:
+            raise RuntimeError(f"Unsupported file format for '{target_run.file_name}'.")
+        
+class WobbleMap:
+    """
+    Class
+    
+    Parameters
+    ----------
+    runs : _type_
+        _description_
+    x_edges : _type_
+        _description_
+    y_edges : _type_
+        _description_
+    e_edges : _type_
+        _description_
+    cuts : _type_
+        _description_
+    time_delta : _type_, optional
+        _description_, by default 0.2*u.hr
+    pointing_delta : _type_, optional
+        _description_, by default 2*u.deg
+    """
+    
     def __init__(self, runs, x_edges, y_edges, e_edges, cuts, time_delta=0.2*u.hr, pointing_delta=2*u.deg):
+        """_summary_
+
+        Parameters
+        ----------
+        runs : _type_
+            _description_
+        x_edges : _type_
+            _description_
+        y_edges : _type_
+            _description_
+        e_edges : _type_
+            _description_
+        cuts : _type_
+            _description_
+        time_delta : _type_, optional
+            _description_, by default 0.2*u.hr
+        pointing_delta : _type_, optional
+            _description_, by default 2*u.deg
+        """
         self.runs           = runs
         self.xedges         = x_edges
         self.yedges         = y_edges
@@ -20,20 +84,21 @@ class _WobbleMap:
         self.pointing_delta = pointing_delta
         
     def get_runwise_bkg(self, target_run)->RectangularCameraImage:
+        """_summary_
+
+        Parameters
+        ----------
+        target_run : _type_
+            _description_
+
+        Returns
+        -------
+        RectangularCameraImage
+            _description_
+        """
         neighbours = find_run_neighbours(target_run, self.runs, self.time_delta, self.pointing_delta)
 
-        if MagicEventFile.is_compatible(target_run.file_name):
-                evtfiles = [
-                    MagicEventFile(run.file_name, cuts=self.cuts)
-                    for run in (target_run,) + neighbours
-                ]
-        elif LstEventFile.is_compatible(target_run.file_name):
-                evtfiles = [
-                    LstEventFile(run.file_name, cuts=self.cuts)
-                    for run in (target_run,) + neighbours
-                ]
-        else:
-            raise RuntimeError(f"Unsupported file format for '{target_run.file_name}'.")
+        evtfiles = self.check_data_format(target_run = target_run, neighbours = neighbours)
 
         images = [
             RectangularCameraImage.from_events(event_file, self.xedges, self.yedges, self.energy_edges)
@@ -57,8 +122,29 @@ class _WobbleMap:
 
         return RectangularCameraImage(counts, self.xedges, self.yedges, self.energy_edges, exposure=exposure)
     
-class _ExclusionMap:
+class ExclusionMap:
     def __init__(self, runs, x_edges, y_edges, e_edges, regions, cuts, time_delta=0.2*u.hr, pointing_delta=2*u.deg):
+        """_summary_
+
+        Parameters
+        ----------
+        runs : _type_
+            _description_
+        x_edges : _type_
+            _description_
+        y_edges : _type_
+            _description_
+        e_edges : _type_
+            _description_
+        regions : _type_
+            _description_
+        cuts : _type_
+            _description_
+        time_delta : _type_, optional
+            _description_, by default 0.2*u.hr
+        pointing_delta : _type_, optional
+            _description_, by default 2*u.deg
+        """
         self.runs           = runs
         self.xedges         = x_edges
         self.yedges         = y_edges
@@ -69,33 +155,26 @@ class _ExclusionMap:
         self.pointing_delta = pointing_delta
 
     def get_runwise_bkg(self, target_run)->RectangularCameraImage:
+        """_summary_
+
+        Parameters
+        ----------
+        target_run : _type_
+            _description_
+
+        Returns
+        -------
+        RectangularCameraImage
+            _description_
+        """
         neighbours = find_run_neighbours(target_run, self.runs, self.time_delta, self.pointing_delta)
 
-        if MagicEventFile.is_compatible(target_run.file_name):
-                evtfiles = [
-                    MagicEventFile(run.file_name, cuts=self.cuts)
-                    for run in (target_run,) + neighbours
-                ]
-        elif LstEventFile.is_compatible(target_run.file_name):
-                evtfiles = [
-                    LstEventFile(run.file_name, cuts=self.cuts)
-                    for run in (target_run,) + neighbours
-                ]
-        else:
-            raise RuntimeError(f"Unsupported file format for '{target_run.file_name}'.")
+        evtfiles = self.check_data_format(target_run = target_run, neighbours = neighbours)
 
         images = [
             RectangularCameraImage.from_events(event_file, self.xedges, self.yedges, self.energy_edges)
             for event_file in evtfiles
         ]
-
-        pointing_ra = u.Quantity([event_file.pointing_ra.mean() for event_file in evtfiles])
-        pointing_dec =  u.Quantity([event_file.pointing_dec.mean() for event_file in evtfiles])
-
-        src_coord = SkyCoord(
-            ra=pointing_ra.mean(),
-            dec=pointing_dec.mean()
-        )
 
         for image in images:
             for region in self.regions:

--- a/src/pybkgmodel/model.py
+++ b/src/pybkgmodel/model.py
@@ -9,79 +9,99 @@ from pybkgmodel.data import RunSummary, find_run_neighbours
 
 from pybkgmodel.camera import RectangularCameraImage
 
+class _WobbleMap:
+    def __init__(self, runs, x_edges, y_edges, e_edges, cuts, time_delta=0.2*u.hr, pointing_delta=2*u.deg):
+        self.runs           = runs
+        self.xedges         = x_edges
+        self.yedges         = y_edges
+        self.energy_edges   = e_edges
+        self.cuts           = cuts
+        self.time_delta     = time_delta
+        self.pointing_delta = pointing_delta
+        
+    def get_runwise_bkg(self, target_run)->RectangularCameraImage:
+        neighbours = find_run_neighbours(target_run, self.runs, self.time_delta, self.pointing_delta)
 
-def runwise_wobble_map(target_run, runs, xedges, yedges, energy_edges, cuts='None', time_delta=0.2*u.hr, pointing_delta=2*u.deg):
-    neighbours = find_run_neighbours(target_run, runs, time_delta, pointing_delta)
+        if MagicEventFile.is_compatible(target_run.file_name):
+                evtfiles = [
+                    MagicEventFile(run.file_name, cuts=self.cuts)
+                    for run in (target_run,) + neighbours
+                ]
+        elif LstEventFile.is_compatible(target_run.file_name):
+                evtfiles = [
+                    LstEventFile(run.file_name, cuts=self.cuts)
+                    for run in (target_run,) + neighbours
+                ]
+        else:
+            raise RuntimeError(f"Unsupported file format for '{target_run.file_name}'.")
+
+        images = [
+            RectangularCameraImage.from_events(event_file, self.xedges, self.yedges, self.energy_edges)
+            for event_file in evtfiles
+        ]
+
+        pointing_ra = u.Quantity([event_file.pointing_ra.mean() for event_file in evtfiles])
+        pointing_dec =  u.Quantity([event_file.pointing_dec.mean() for event_file in evtfiles])
+
+        src_coord = SkyCoord(
+            ra=pointing_ra.mean(),
+            dec=pointing_dec.mean()
+        )
+
+        for image in images:
+            src_cam = src_coord.transform_to(image.center.skyoffset_frame())
+            image.mask_half(src_cam)
+
+        counts = numpy.sum([im.counts for im in images], axis=0)
+        exposure = u.Quantity([im.exposure for im in images]).sum(axis=0)
+
+        return RectangularCameraImage(counts, self.xedges, self.yedges, self.energy_edges, exposure=exposure)
     
-    if MagicEventFile.is_compatible(target_run.file_name):
-            evtfiles = [
-                MagicEventFile(run.file_name, cuts=cuts)
-                for run in (target_run,) + neighbours
-            ]
-    elif LstEventFile.is_compatible(target_run.file_name):
-            evtfiles = [
-                LstEventFile(run.file_name, cuts=cuts)
-                for run in (target_run,) + neighbours
-            ]
-    else:
-        raise RuntimeError(f"Unsupported file format for '{target_run.file_name}'.")
-    
-    images = [
-        RectangularCameraImage.from_events(event_file, xedges, yedges, energy_edges)
-        for event_file in evtfiles
-    ]
+class _ExclusionMap:
+    def __init__(self, runs, x_edges, y_edges, e_edges, regions, cuts, time_delta=0.2*u.hr, pointing_delta=2*u.deg):
+        self.runs           = runs
+        self.xedges         = x_edges
+        self.yedges         = y_edges
+        self.energy_edges   = e_edges
+        self.regions        = regions
+        self.cuts           = cuts
+        self.time_delta     = time_delta
+        self.pointing_delta = pointing_delta
 
-    pointing_ra = u.Quantity([event_file.pointing_ra.mean() for event_file in evtfiles])
-    pointing_dec =  u.Quantity([event_file.pointing_dec.mean() for event_file in evtfiles])
+    def get_runwise_bkg(self, target_run)->RectangularCameraImage:
+        neighbours = find_run_neighbours(target_run, self.runs, self.time_delta, self.pointing_delta)
 
-    src_coord = SkyCoord(
-        ra=pointing_ra.mean(),
-        dec=pointing_dec.mean()
-    )
+        if MagicEventFile.is_compatible(target_run.file_name):
+                evtfiles = [
+                    MagicEventFile(run.file_name, cuts=self.cuts)
+                    for run in (target_run,) + neighbours
+                ]
+        elif LstEventFile.is_compatible(target_run.file_name):
+                evtfiles = [
+                    LstEventFile(run.file_name, cuts=self.cuts)
+                    for run in (target_run,) + neighbours
+                ]
+        else:
+            raise RuntimeError(f"Unsupported file format for '{target_run.file_name}'.")
 
-    for image in images:
-        src_cam = src_coord.transform_to(image.center.skyoffset_frame())
-        image.mask_half(src_cam)
+        images = [
+            RectangularCameraImage.from_events(event_file, self.xedges, self.yedges, self.energy_edges)
+            for event_file in evtfiles
+        ]
 
-    counts = numpy.sum([im.counts for im in images], axis=0)
-    exposure = u.Quantity([im.exposure for im in images]).sum(axis=0)
+        pointing_ra = u.Quantity([event_file.pointing_ra.mean() for event_file in evtfiles])
+        pointing_dec =  u.Quantity([event_file.pointing_dec.mean() for event_file in evtfiles])
 
-    return RectangularCameraImage(counts, xedges, yedges, energy_edges, exposure=exposure)
+        src_coord = SkyCoord(
+            ra=pointing_ra.mean(),
+            dec=pointing_dec.mean()
+        )
 
-def runwise_exclusion_map(target_run, runs, xedges, yedges, energy_edges, regions, cuts='None', time_delta=0.2*u.hr, pointing_delta=2*u.deg):
-    neighbours = find_run_neighbours(target_run, runs, time_delta, pointing_delta)
-    
-    if MagicEventFile.is_compatible(target_run.file_name):
-            evtfiles = [
-                MagicEventFile(run.file_name, cuts=cuts)
-                for run in (target_run,) + neighbours
-            ]
-    elif LstEventFile.is_compatible(target_run.file_name):
-            evtfiles = [
-                LstEventFile(run.file_name, cuts=cuts)
-                for run in (target_run,) + neighbours
-            ]
-    else:
-        raise RuntimeError(f"Unsupported file format for '{target_run.file_name}'.")
-    
-    images = [
-        RectangularCameraImage.from_events(event_file, xedges, yedges, energy_edges)
-        for event_file in evtfiles
-    ]
+        for image in images:
+            for region in self.regions:
+                image.mask_region(region[0])
 
-    pointing_ra = u.Quantity([event_file.pointing_ra.mean() for event_file in evtfiles])
-    pointing_dec =  u.Quantity([event_file.pointing_dec.mean() for event_file in evtfiles])
+        counts = numpy.sum([im.counts for im in images], axis=0)
+        exposure = u.Quantity([im.exposure for im in images]).sum(axis=0)
 
-    src_coord = SkyCoord(
-        ra=pointing_ra.mean(),
-        dec=pointing_dec.mean()
-    )
-
-    for image in images:
-        for region in regions:
-            image.mask_region(region[0])
-
-    counts = numpy.sum([im.counts for im in images], axis=0)
-    exposure = u.Quantity([im.exposure for im in images]).sum(axis=0)
-
-    return RectangularCameraImage(counts, xedges, yedges, energy_edges, exposure=exposure)
+        return RectangularCameraImage(counts, self.xedges, self.yedges, self.energy_edges, exposure=exposure)

--- a/src/pybkgmodel/model.py
+++ b/src/pybkgmodel/model.py
@@ -1,79 +1,116 @@
 import numpy
-import os
 import astropy.units as u
 
 from astropy.coordinates import SkyCoord
 
 from pybkgmodel.data import MagicEventFile, LstEventFile
-from pybkgmodel.data import RunSummary, find_run_neighbours
+from pybkgmodel.data import find_run_neighbours
 
 from pybkgmodel.camera import RectangularCameraImage
 
+
 class BaseMap:
-    
+
+    """
+    Base class for the runwise background map reconstruction methods.
+    Not intended to be used directly, bust just defines some common
+    procedures for all background methods.
+    """
+
     def __init__(self):
         pass
 
-    def get_runwise_bkg(self):
-        pass
-
-    def check_data_format(self, target_run, neighbours):
-        if MagicEventFile.is_compatible(target_run.file_name):
-                evtfiles = [
-                    MagicEventFile(run.file_name, cuts=self.cuts)
-                    for run in (target_run,) + neighbours
-                ]
-                return evtfiles
-        elif LstEventFile.is_compatible(target_run.file_name):
-                evtfiles = [
-                    LstEventFile(run.file_name, cuts=self.cuts)
-                    for run in (target_run,) + neighbours
-                ]
-                return evtfiles
-        else:
-            raise RuntimeError(f"Unsupported file format for '{target_run.file_name}'.")
-        
-class WobbleMap:
-    """
-    Class
-    
-    Parameters
-    ----------
-    runs : _type_
-        _description_
-    x_edges : _type_
-        _description_
-    y_edges : _type_
-        _description_
-    e_edges : _type_
-        _description_
-    cuts : _type_
-        _description_
-    time_delta : _type_, optional
-        _description_, by default 0.2*u.hr
-    pointing_delta : _type_, optional
-        _description_, by default 2*u.deg
-    """
-    
-    def __init__(self, runs, x_edges, y_edges, e_edges, cuts, time_delta=0.2*u.hr, pointing_delta=2*u.deg):
-        """_summary_
+    def read_runs(self, target_run, neighbours, cuts):
+        """Function loading the event from the run file into event file objects.
 
         Parameters
         ----------
-        runs : _type_
-            _description_
-        x_edges : _type_
-            _description_
-        y_edges : _type_
-            _description_
-        e_edges : _type_
-            _description_
-        cuts : _type_
-            _description_
-        time_delta : _type_, optional
-            _description_, by default 0.2*u.hr
-        pointing_delta : _type_, optional
-            _description_, by default 2*u.deg
+        target_run : str
+            Run for which the file shall be read.
+        neighbours : tuple
+            Neighbouring runs selected.
+        cuts : str
+            Event selection cuts.
+
+        Returns
+        -------
+        evtfiles : list
+            List of the event files objects is returned.
+
+        Raises
+        ------
+        RuntimeError
+            Raise if a run in an unsupported format is provided.
+            Currenttly supported formats are DL2 for LST and ROOT for MAGIC.
+        """
+        if MagicEventFile.is_compatible(target_run.file_name):
+            evtfiles = [
+            MagicEventFile(run.file_name, cuts=cuts)
+            for run in (target_run,) + neighbours
+            ]
+            return evtfiles
+        elif LstEventFile.is_compatible(target_run.file_name):
+            evtfiles = [
+            LstEventFile(run.file_name, cuts=cuts)
+            for run in (target_run,) + neighbours
+            ]
+            return evtfiles
+        else:
+            raise RuntimeError(f"Unsupported file format for '{target_run.file_name}'.")
+
+
+class WobbleMap(BaseMap):
+    """
+    Class for generating runwise background maps using the wobble map algorithm.
+
+    Attributes
+    ----------
+    runs : tuple
+        Source data.
+    x_edges : numpy.ndarray
+        Array of the bin edges along the x/azimuth axis; linear binning.
+    y_edges : numpy.ndarray
+        Array of the bin edges along the y/Zenith axis; linear binning.
+    e_edges : numpy.ndarray
+        Array of the bin edges in energy; logarithmic binning.
+    cuts : str
+        Event selection cuts.
+    time_delta : astropy.units.quantity.Quantity
+        Time difference between runs for the run matching, by default 0.2*u.hr.
+    pointing_delta : astropy.units.quantity.Quantity
+        Pointing difference between runs for run matching, by default 2*u.deg.
+    """
+
+    def __init__(self,
+                 runs,
+                 x_edges,
+                 y_edges,
+                 e_edges,
+                 cuts,
+                 time_delta=0.2*u.hr,
+                 pointing_delta=2*u.deg
+                 ):
+        """
+        Function initializing a class for generating runwise background maps using
+        the wobble map algorithm.
+
+
+        Parameters
+        ----------
+        runs : tuple
+            Source data.
+        x_edges : numpy.ndarray
+            Array of the bin edges along the x/azimuth axis; linear binning.
+        y_edges : numpy.ndarray
+            Array of the bin edges along the y/Zenith axis; linear binning.
+        e_edges : numpy.ndarray
+            Array of the bin edges in energy; logarithmic binning.
+        cuts : str
+            Event selection cuts.
+        time_delta : astropy.units.quantity.Quantity
+            Time difference between runs for the run matching, by default 0.2*u.hr.
+        pointing_delta : astropy.units.quantity.Quantity
+            Pointing difference between runs for run matching, by default 2*u.deg.
         """
         self.runs           = runs
         self.xedges         = x_edges
@@ -82,31 +119,46 @@ class WobbleMap:
         self.cuts           = cuts
         self.time_delta     = time_delta
         self.pointing_delta = pointing_delta
-        
+
     def get_runwise_bkg(self, target_run)->RectangularCameraImage:
-        """_summary_
+        """Function for obtaining runwise background maps using the Wobble
+        map method.
 
         Parameters
         ----------
-        target_run : _type_
-            _description_
+        target_run : RunSummary
+            Run for which the background map shall be generated.
 
         Returns
         -------
         RectangularCameraImage
-            _description_
+            Returns a camera object containing the event counts and exposure
+            for each camera bin.
         """
-        neighbours = find_run_neighbours(target_run, self.runs, self.time_delta, self.pointing_delta)
+        neighbours = find_run_neighbours(target_run,
+                                         self.runs,
+                                         self.time_delta,
+                                         self.pointing_delta
+                                         )
 
-        evtfiles = self.check_data_format(target_run = target_run, neighbours = neighbours)
+        evtfiles = self.read_runs(target_run = target_run,
+                                          neighbours = neighbours,
+                                          cuts = self.cuts
+                                          )
 
         images = [
-            RectangularCameraImage.from_events(event_file, self.xedges, self.yedges, self.energy_edges)
+            RectangularCameraImage.from_events(event_file,
+                                               self.xedges,
+                                               self.yedges,
+                                               self.energy_edges
+                                               )
             for event_file in evtfiles
         ]
 
-        pointing_ra = u.Quantity([event_file.pointing_ra.mean() for event_file in evtfiles])
-        pointing_dec =  u.Quantity([event_file.pointing_dec.mean() for event_file in evtfiles])
+        pointing_ra = u.Quantity([event_file.pointing_ra.mean() for event_file
+                                  in evtfiles])
+        pointing_dec =  u.Quantity([event_file.pointing_dec.mean() for event_file
+                                    in evtfiles])
 
         src_coord = SkyCoord(
             ra=pointing_ra.mean(),
@@ -120,30 +172,70 @@ class WobbleMap:
         counts = numpy.sum([im.counts for im in images], axis=0)
         exposure = u.Quantity([im.exposure for im in images]).sum(axis=0)
 
-        return RectangularCameraImage(counts, self.xedges, self.yedges, self.energy_edges, exposure=exposure)
-    
-class ExclusionMap:
-    def __init__(self, runs, x_edges, y_edges, e_edges, regions, cuts, time_delta=0.2*u.hr, pointing_delta=2*u.deg):
-        """_summary_
+        return RectangularCameraImage(counts, self.xedges,
+                                      self.yedges,
+                                      self.energy_edges,
+                                      exposure=exposure
+                                      )
+
+class ExclusionMap(BaseMap):
+    """
+    Class for generating runwise background maps using the exclusion map
+    algorithm.
+
+    Attributes
+    ----------
+    runs : tuple
+        Source data.
+    x_edges : numpy.ndarray
+        Array of the bin edges along the x/azimuth axis; linear binning.
+    y_edges : numpy.ndarray
+        Array of the bin edges along the y/Zenith axis; linear binning.
+    e_edges : numpy.ndarray
+        Array of the bin edges in energy; logarithmic binning.
+    excl_region : list
+        List of regions to be excluded from the background map in ds9
+        format.
+    cuts : str
+        Event selection cuts.
+    time_delta : astropy.units.quantity.Quantity
+        Time difference between runs for the run matching, by default 0.2*u.hr.
+    pointing_delta : astropy.units.quantity.Quantity
+        Pointing difference between runs for run matching, by default 2*u.deg.
+    """
+    def __init__(self,
+                 runs,
+                 x_edges,
+                 y_edges,
+                 e_edges,
+                 regions,
+                 cuts,
+                 time_delta=0.2*u.hr,
+                 pointing_delta=2*u.deg
+                 ):
+        """
+        Function initializing a class for generating runwise background maps using
+        the exclusion map algorithm.
 
         Parameters
         ----------
-        runs : _type_
-            _description_
-        x_edges : _type_
-            _description_
-        y_edges : _type_
-            _description_
-        e_edges : _type_
-            _description_
-        regions : _type_
-            _description_
-        cuts : _type_
-            _description_
-        time_delta : _type_, optional
-            _description_, by default 0.2*u.hr
-        pointing_delta : _type_, optional
-            _description_, by default 2*u.deg
+        runs : tuple
+            Source data.
+        x_edges : numpy.ndarray
+            Array of the bin edges along the x/azimuth axis; linear binning.
+        y_edges : numpy.ndarray
+            Array of the bin edges along the y/Zenith axis; linear binning.
+        e_edges : numpy.ndarray
+            Array of the bin edges in energy; logarithmic binning.
+        excl_region : list
+            List of regions to be excluded from the background map in ds9
+            format.
+        cuts : str
+            Event selection cuts.
+        time_delta : astropy.units.quantity.Quantity
+            Time difference between runs for the run matching, by default 0.2*u.hr.
+        pointing_delta : astropy.units.quantity.Quantity
+            Pointing difference between runs for run matching, by default 2*u.deg.
         """
         self.runs           = runs
         self.xedges         = x_edges
@@ -155,24 +247,37 @@ class ExclusionMap:
         self.pointing_delta = pointing_delta
 
     def get_runwise_bkg(self, target_run)->RectangularCameraImage:
-        """_summary_
+        """Function for obtaining runwise background maps using the Exclusion
+        map method.
 
         Parameters
         ----------
-        target_run : _type_
-            _description_
+        target_run : RunSummary
+            Run for which the background map shall be generated.
 
         Returns
         -------
         RectangularCameraImage
-            _description_
+            Returns a camera object containing the event counts and exposure
+            for each camera bin.
         """
-        neighbours = find_run_neighbours(target_run, self.runs, self.time_delta, self.pointing_delta)
+        neighbours = find_run_neighbours(target_run,
+                                         self.runs,
+                                         self.time_delta,
+                                         self.pointing_delta
+                                         )
 
-        evtfiles = self.check_data_format(target_run = target_run, neighbours = neighbours)
+        evtfiles = self.read_runs(target_run = target_run,
+                                          neighbours = neighbours,
+                                          cuts = self.cuts
+                                          )
 
         images = [
-            RectangularCameraImage.from_events(event_file, self.xedges, self.yedges, self.energy_edges)
+            RectangularCameraImage.from_events(event_file,
+                                               self.xedges,
+                                               self.yedges,
+                                               self.energy_edges
+                                               )
             for event_file in evtfiles
         ]
 
@@ -183,4 +288,9 @@ class ExclusionMap:
         counts = numpy.sum([im.counts for im in images], axis=0)
         exposure = u.Quantity([im.exposure for im in images]).sum(axis=0)
 
-        return RectangularCameraImage(counts, self.xedges, self.yedges, self.energy_edges, exposure=exposure)
+        return RectangularCameraImage(counts,
+                                      self.xedges,
+                                      self.yedges,
+                                      self.energy_edges,
+                                      exposure=exposure
+                                      )

--- a/src/pybkgmodel/processing.py
+++ b/src/pybkgmodel/processing.py
@@ -11,242 +11,331 @@ except:
 import astropy.units as u
 
 from pybkgmodel.data import RunSummary
-from pybkgmodel.model import runwise_wobble_map, runwise_exclusion_map
+from pybkgmodel.model import _WobbleMap, _ExclusionMap
 from pybkgmodel.camera import RectangularCameraImage
 
-
-def process_runwise_wobble_map(config):
-    cuts = config['data']['cuts']
-
-    xedges = numpy.linspace(
-        u.Quantity(config['binning']['x']['min']),
-        u.Quantity(config['binning']['x']['max']),
-        num=config['binning']['x']['n']+1
-    )
-    yedges = numpy.linspace(
-        u.Quantity(config['binning']['y']['min']),
-        u.Quantity(config['binning']['y']['max']),
-        num=config['binning']['y']['n']+1
-    )
-    energy_edges = numpy.geomspace(
-        u.Quantity(config['binning']['energy']['min']),
-        u.Quantity(config['binning']['energy']['max']),
-        num=config['binning']['energy']['n']+1
-    )
-
-    files = glob.glob(config['data']['mask'])
-
-    runs = [RunSummary(fname) for fname in files]
-    runs = tuple(filter(lambda r: r.obs_id is not None, runs))
-
-    with progressbar.ProgressBar(max_value=len(runs)) as progress:
-        for ri, run in enumerate(runs):
+class _BkgMakerBase:
+    """ 
+    A class used to store the settings from the configuation file and to 
+    facilitate the generation of background maps.
+    
+    Attributes
+    ----------
+    files : list
+        List of paths to the files corresponding to the data mask.
+    runs : tuple
+        Source data.
+    cuts : str
+        Event selection cuts.
+    out_dir : str
+        Path where to write the output files to.
+    out_prefix : str
+        Prefix of the output filename.
+    overwrite:  bool
+        Whether to overwrite existing output files of same name.
+    time_delta : astropy.units.quantity.Quantity
+        Time difference between runs for the run matching. 
+    pointing_delta : astropy.units.quantity.Quantity
+        Pointing difference between runs for run matching.   
+    x_edges : numpy.ndarray
+        Array of the bin edges along the x/azimuth axis; linear binning.
+    y_edges : numpy.ndarray
+        Array of the bin edges along the y/Zenith axis; linear binning.
+    e_edges : numpy.ndarray
+        Array of the bin edges in energy; logarithmic binning.  
+    excl_region : str
+        Region to be excluded from the bkg model in ds9 region format.
+    bkg_maps : dict 
+        Dictionary containing the generated bkg maps and output names for each
+        run.
+    """    
+    
+    def __init__(self, 
+                 files, 
+                 cuts, 
+                 out_dir, 
+                 out_prefix, 
+                 overwrite, 
+                 time_delta, 
+                 pointing_delta, 
+                 x_min, 
+                 x_max, 
+                 y_min,
+                 y_max, 
+                 x_nbins, 
+                 y_nbins,
+                 e_min,
+                 e_max,
+                 e_nbins,
+                 excl_region
+                 ) -> None:  
+        
+        """
+        Function initializing a prozessing object.
+        
+        Parameters
+        ----------
+        files : list
+            List of paths to the files corresponding to the data mask.
+        cuts : str
+            Event selection cuts.
+        out_dir : str
+            Path where to write the output files to.
+        out_prefix : str
+            Prefix of the output filename.
+        overwrite:  bool
+            Whether to overwrite existing output files of same name.
+        time_delta : astropy.units.quantity.Quantity
+            Time difference between runs for the run matching. 
+        pointing_delta : astropy.units.quantity.Quantity
+            Pointing difference between runs for run matching.   
+        x_min : astropy.units.quantity.Quantity
+            Minimal positon along the x/azimuth axis.
+        x_max : astropy.units.quantity.Quantity
+            Maximum positon along the x/azimuth axis.
+        x_nbins : int
+            Number of bins along the x/azimuth axis.
+        y_min : astropy.units.quantity.Quantity
+            Minimal positon along the y/Zenith axis.
+        y_max : astropy.units.quantity.Quantity
+            Maximum positon along the y/Zenith axis.
+        y_nbins : int
+            Number of bins along the y/Zenith axis.
+        e_min : astropy.units.quantity.Quantity
+            Minimal energy edge of the bkg maps.
+        e_max : astropy.units.quantity.Quantity
+            Maximum energy edge of the bkg maps.
+        e_nbins : int
+            Number of bins along the energy axis
+        excl_region : str
+            Region to be excluded from the bkg model in ds9 region format.
             
-            # TODO: get all params via config
-            bkg_map = runwise_wobble_map(
-                run,
-                runs,
-                xedges,
-                yedges,
-                energy_edges,
-                cuts=cuts,
-                time_delta=0.2*u.hr,
-                pointing_delta=2*u.deg
-            )
+         Returns
+        -------
+        out
+            processing object
+        """        
+        
+        self.files          = files
+        self.runs           = tuple(filter(lambda r: r.obs_id is not None, 
+                                           [RunSummary(fname) for fname in 
+                                            self.files]
+                                           )
+                                    )
+        self.cuts           = cuts
+        
+        self.out_dir        = out_dir
+        self.out_prefix     = out_prefix 
+        self.overwrite      = overwrite
+                                       
+        self.time_delta     = time_delta
+        self.pointing_delta = pointing_delta
+        
+        self.x_edges        = numpy.linspace(x_min,  
+                                             x_max, 
+                                             x_nbins+1)
+        
+        self.y_edges        = numpy.linspace(y_min,  
+                                             y_max, 
+                                             y_nbins+1)
+        
+        self.e_edges        = numpy.geomspace(e_min, 
+                                              e_max, 
+                                              e_nbins+1) 
+        
+        self.excl_region    = [Regions.parse(reg,format='ds9') for reg in 
+                               excl_region]
+        
+        self.bkg_maps   = {}   
+        
+        # self._bkg_reco_method = None
 
-            base_name = os.path.basename(run.file_name)
-            base_name, _ = os.path.splitext(base_name)
+    @classmethod
+    def from_config_file(cls, config):
+        """
+        Function initializing a prozessing object from an input dictionary.
+        
+        Parameters
+        ----------
+        config : dict
+            dictionary containing the settings read from the yaml configuration
+            file.
             
-            output_name = os.path.join(
-            config['output']['directory'],
-            f"{config['output']['prefix']}{base_name}.fits"
+        Raises
+        ------
+        ValueError
+            Error is raised if no input dictionary is provided.
+        """ 
+        
+        if config is None:
+            raise ValueError(
+                "No configuration file provided."
             )
-            if not config['output']['overwrite']:
-                if os.path.exists(output_name):
-                    print('Output file %s already existing. Abort'%output_name)
-                    sys.exit()
+        
+        return cls(
+                    files          = glob.glob(config['data']['mask']),
 
-            bkg_map.to_hdu().writeto(output_name, overwrite=config['output']['overwrite'])
+                    cuts           = config['data']['cuts'],
+        
+                    out_dir        = config['output']['directory'],
+                    out_prefix     = config['output']['prefix'],
+                    overwrite      = config['output']['overwrite'],           
+                    
+                    time_delta     = u.Quantity(config['run_matching']\
+                                                      ['time_delta']),
+                    pointing_delta = u.Quantity(config['run_matching']\
+                                                      ['pointing_delta']),   
+        
+                    x_min          = u.Quantity(config['binning']['x']['min']),
+                    x_max          = u.Quantity(config['binning']['x']['max']),
+                    y_min          = u.Quantity(config['binning']['y']['min']),
+                    y_max          = u.Quantity(config['binning']['y']['max']),
+                    x_nbins        = config['binning']['x']['nbins'],
+                    y_nbins        = config['binning']['y']['nbins'],
 
-            progress.update(ri)
+                    e_min          = u.Quantity(config['binning']['energy']\
+                                                      ['min']),
+                    e_max          = u.Quantity(config['binning']['energy']\
+                                                      ['max']),
+                    e_nbins        = config['binning']['energy']['nbins'],
+      
+                    excl_region    = config['exclusion_regions']
+        )
 
+    def _generate_runwise_maps(self) -> dict:
+        """
+        Returns a dictionary containing the runwise bkg maps and output file names
+        for each input run.
 
-def process_stacked_wobble_map(config):
+        Returns
+        -------
+        dict
+            {'maps', 'outnames'}
+        """        
+        maps = {}  
+        
+        with progressbar.ProgressBar(max_value=len(self.runs)) as progress:
+            for ri, run in enumerate(self.runs):
+                
+                bkg_map = self._bkg_reco_method.get_runwise_bkg(target_run = run)
+                
+                base_name = os.path.basename(run.file_name)
+                base_name, _ = os.path.splitext(base_name)
+                
+                output_name = os.path.join(
+                                        self.out_dir,
+                                        f"{self.out_prefix}{base_name}.fits"
+                                        )
+                
+                maps['{}'.format(output_name)] = bkg_map
+                  
+                progress.update(ri)
+        
+        self.bkg_maps = maps
+        
+        return maps
     
-    output_name = os.path.join(
-        config['output']['directory'],
-        f"{config['output']['prefix']}stacked_wobble_map.fits"
-    )    
-    if not config['output']['overwrite']:
-        if os.path.exists(output_name):
-            print('Output file %s already existing. Abort'%output_name)
-            sys.exit()
+    def _stack_maps(self) -> RectangularCameraImage:
+        """
+        Returns a stacked bkg map of all the runs.
+
+        Returns
+        -------
+        RectangularCameraImage
+        """        
+        counts = numpy.sum([m.counts for m in self.bkg_maps.values()],
+                           axis=0)
+        exposure = u.Quantity([m.exposure for m in self.bkg_maps.values()]
+                              ).sum(axis=0)
+        stacked_map = RectangularCameraImage(counts, 
+                                             self.x_edges, 
+                                             self.y_edges, 
+                                             self.e_edges, 
+                                             exposure=exposure)
+        return stacked_map
+        
+    def _write_maps(self) -> None:
+        """
+        This method writes the generated bkgmaps to the corresponding output
+        path. The output follows the definition in 
+        https://gamma-astro-data-formats.readthedocs.io/
+        """        
+                                           
+        for key in self.bkg_maps.keys():
+            self.bkg_maps[key].to_hdu().writeto(key, overwrite=self.overwrite)    
+
+class _Runwise(_BkgMakerBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
     
-    cuts = config['data']['cuts']
+    def get_maps(self):
+        self._generate_runwise_maps()
+        self._write_maps()
+        return self.bkg_maps
 
-    xedges = numpy.linspace(
-        u.Quantity(config['binning']['x']['min']),
-        u.Quantity(config['binning']['x']['max']),
-        num=config['binning']['x']['n']+1
-    )
-    yedges = numpy.linspace(
-        u.Quantity(config['binning']['y']['min']),
-        u.Quantity(config['binning']['y']['max']),
-        num=config['binning']['y']['n']+1
-    )
-    energy_edges = numpy.geomspace(
-        u.Quantity(config['binning']['energy']['min']),
-        u.Quantity(config['binning']['energy']['max']),
-        num=config['binning']['energy']['n']+1
-    )
-
-    files = glob.glob(config['data']['mask'])
-
-    runs = [RunSummary(fname) for fname in files]
-    runs = tuple(filter(lambda r: r.obs_id is not None, runs))
-
-    with progressbar.ProgressBar(max_value=len(runs)) as progress:
-        maps = []
-        for ri, run in enumerate(runs):
-            # TODO: get all params via config
-            map_ = runwise_wobble_map(
-                run,
-                runs,
-                xedges,
-                yedges,
-                energy_edges,
-                cuts=cuts,
-                time_delta=0.2*u.hr,
-                pointing_delta=2*u.deg
-            )
-
-            maps.append(map_)
-
-            progress.update(ri)
-
-    counts = numpy.sum([m.counts for m in maps], axis=0)
-    exposure = u.Quantity([m.exposure for m in maps]).sum(axis=0)
-    stacked_map = RectangularCameraImage(counts, xedges, yedges, energy_edges, exposure=exposure)
-
-    stacked_map.to_hdu().writeto(output_name, overwrite=config['output']['overwrite'])
-
-
-def process_runwise_exclusion_map(config):
-    cuts = config['data']['cuts']
+class _Stacked(_BkgMakerBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
     
-    regions = [Regions.parse(reg,format='ds9') for reg in config['exclusion_regions']]
-
-    xedges = numpy.linspace(
-        u.Quantity(config['binning']['x']['min']),
-        u.Quantity(config['binning']['x']['max']),
-        num=config['binning']['x']['n']+1
-    )
-    yedges = numpy.linspace(
-        u.Quantity(config['binning']['y']['min']),
-        u.Quantity(config['binning']['y']['max']),
-        num=config['binning']['y']['n']+1
-    )
-    energy_edges = numpy.geomspace(
-        u.Quantity(config['binning']['energy']['min']),
-        u.Quantity(config['binning']['energy']['max']),
-        num=config['binning']['energy']['n']+1
-    )
-
-    files = glob.glob(config['data']['mask'])
-
-    runs = [RunSummary(fname) for fname in files]
-    runs = tuple(filter(lambda r: r.obs_id is not None, runs))
-
-    with progressbar.ProgressBar(max_value=len(runs)) as progress:
-        for ri, run in enumerate(runs):
-            
-            # TODO: get all params via config
-            bkg_map = runwise_exclusion_map(
-                run,
-                runs,
-                xedges,
-                yedges,
-                energy_edges,
-                regions,
-                cuts=cuts,
-                time_delta=0.2*u.hr,
-                pointing_delta=2*u.deg
-            )
-
-            base_name = os.path.basename(run.file_name)
-            base_name, _ = os.path.splitext(base_name)
-            
-            output_name = os.path.join(
-            config['output']['directory'],
-            f"{config['output']['prefix']}{base_name}.fits"
-            )
-            if not config['output']['overwrite']:
-                if os.path.exists(output_name):
-                    print('Output file %s already existing. Abort'%output_name)
-                    sys.exit()
-
-            bkg_map.to_hdu().writeto(output_name, overwrite=config['output']['overwrite'])
-
-            progress.update(ri)
-
-def process_stacked_exclusion_map(config):
+    def get_maps(self):
+        maps = self._generate_runwise_maps()
+        stacked_map = self._stack_maps()
+        
+        stacked_name = os.path.join(
+                self.out_dir,
+                f"{self.out_prefix}stacked_bkg_map.fits"
+                )   
+        self.bkg_maps = {stacked_name: stacked_map}
+        self._write_maps()
+        return self.bkg_maps
     
-    output_name = os.path.join(
-        config['output']['directory'],
-        f"{config['output']['prefix']}stacked_exclusion_map.fits"
-    )    
-    if not config['output']['overwrite']:
-        if os.path.exists(output_name):
-            print('Output file %s already existing. Abort'%output_name)
-            sys.exit()
-    
-    cuts = config['data']['cuts']
-    
-    regions = [Regions.parse(reg,format='ds9') for reg in config['exclusion_regions']]
+class RunwiseWobbleMap(_Runwise):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._bkg_reco_method = _WobbleMap(runs=self.runs,
+                                           x_edges=self.x_edges,
+                                           y_edges=self.y_edges,
+                                           e_edges=self.e_edges,
+                                           cuts=self.cuts,
+                                           time_delta=self.time_delta,
+                                           pointing_delta=self.pointing_delta
+                                           )
+        
 
-    xedges = numpy.linspace(
-        u.Quantity(config['binning']['x']['min']),
-        u.Quantity(config['binning']['x']['max']),
-        num=config['binning']['x']['n']+1
-    )
-    yedges = numpy.linspace(
-        u.Quantity(config['binning']['y']['min']),
-        u.Quantity(config['binning']['y']['max']),
-        num=config['binning']['y']['n']+1
-    )
-    energy_edges = numpy.geomspace(
-        u.Quantity(config['binning']['energy']['min']),
-        u.Quantity(config['binning']['energy']['max']),
-        num=config['binning']['energy']['n']+1
-    )
+class StackedWobbleMap(_Stacked):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._bkg_reco_method = _WobbleMap(runs=self.runs,
+                                           x_edges=self.x_edges,
+                                           y_edges=self.y_edges,
+                                           e_edges=self.e_edges,
+                                           cuts=self.cuts,
+                                           time_delta=self.time_delta,
+                                           pointing_delta=self.pointing_delta
+                                           )
 
-    files = glob.glob(config['data']['mask'])
+class RunwiseExclusionMap(_Runwise):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._bkg_reco_method = _ExclusionMap(runs=self.runs,
+                                              x_edges=self.x_edges,
+                                              y_edges=self.y_edges,
+                                              e_edges=self.e_edges,
+                                              regions=self.excl_region,
+                                              cuts=self.cuts,
+                                              time_delta=self.time_delta,
+                                              pointing_delta=self.pointing_delta
+                                              )
 
-    runs = [RunSummary(fname) for fname in files]
-    runs = tuple(filter(lambda r: r.obs_id is not None, runs))
-
-    with progressbar.ProgressBar(max_value=len(runs)) as progress:
-        maps = []
-        for ri, run in enumerate(runs):
-            # TODO: get all params via config
-            map_ = runwise_exclusion_map(
-                run,
-                runs,
-                xedges,
-                yedges,
-                energy_edges,
-                regions,
-                cuts=cuts,
-                time_delta=0.2*u.hr,
-                pointing_delta=2*u.deg
-            )
-
-            maps.append(map_)
-
-            progress.update(ri)
-
-    counts = numpy.sum([m.counts for m in maps], axis=0)
-    exposure = u.Quantity([m.exposure for m in maps]).sum(axis=0)
-    stacked_map = RectangularCameraImage(counts, xedges, yedges, energy_edges, exposure=exposure)
-
-    stacked_map.to_hdu().writeto(output_name, overwrite=config['output']['overwrite'])
+class StackedExclusionMap(_Stacked):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._bkg_reco_method = _ExclusionMap(runs=self.runs,
+                                              x_edges=self.x_edges,
+                                              y_edges=self.y_edges,
+                                              e_edges=self.e_edges,
+                                              regions=self.excl_region,
+                                              cuts=self.cuts,
+                                              time_delta=self.time_delta,
+                                              pointing_delta=self.pointing_delta
+                                              )

--- a/src/pybkgmodel/processing.py
+++ b/src/pybkgmodel/processing.py
@@ -1,38 +1,41 @@
 from functools import reduce
 import glob
 import inspect
-import numpy
 from operator import getitem
 import os
-from regions import Regions
 import sys
+
+import numpy
+from regions import Regions
 try:
     import progressbar
-except:
+except: # pylint: disable=bare-except
     print('Please install the progressbar2 module (not progressbar)')
     sys.exit()
 import astropy.units as u
 
 from pybkgmodel.data import RunSummary
-from pybkgmodel.model import BaseMap, WobbleMap, ExclusionMap
+from pybkgmodel.model import (WobbleMap,
+                              ExclusionMap
+                            )
 from pybkgmodel.camera import RectangularCameraImage
 
 # list of class attributes, which have a unit assigned
 quantity_list = [
-                'time_delta', 
-                'pointing_delta', 
-                'x_min', 
-                'x_max', 
-                'y_min', 
-                'y_max', 
-                'e_min', 
+                'time_delta',
+                'pointing_delta',
+                'x_min',
+                'x_max',
+                'y_min',
+                'y_max',
+                'e_min',
                 'e_max'
                 ]
 
 # dictionary to map names in the config file to the class attribute names
 config_class_map = {
     'files' : ['data', 'mask'],
-    'cuts' : ['data', 'cuts'], 
+    'cuts' : ['data', 'cuts'],
     'out_dir' : ['output', 'directory'],
     'out_prefix' : ['output', 'prefix'],
     'overwrite' : ['output', 'overwrite'],
@@ -51,10 +54,10 @@ config_class_map = {
 }
 
 class BkgMakerBase:
-    """ 
-    A class used to store the settings from the configuation file and to 
+    """
+    A class used to store the settings from the configuation file and to
     facilitate the generation of background maps.
-    
+
     Attributes
     ----------
     files : list
@@ -68,42 +71,42 @@ class BkgMakerBase:
     out_prefix : str
         Prefix of the output filename.
     overwrite:  bool
-        Whether to overwrite existing output files of same name. 
+        Whether to overwrite existing output files of same name.
     x_edges : numpy.ndarray
         Array of the bin edges along the x/azimuth axis; linear binning.
     y_edges : numpy.ndarray
         Array of the bin edges along the y/Zenith axis; linear binning.
     e_edges : numpy.ndarray
-        Array of the bin edges in energy; logarithmic binning.  
-    bkg_maps : dict 
+        Array of the bin edges in energy; logarithmic binning.
+    bkg_maps : dict
         Dictionary containing the generated bkg maps and output names for each
         run.
     bkg_map_maker : class
         Class of the background reconstruction algorithm used to obtain the
         runwise background maps.
-    """    
-    
+    """
+
     def __init__(
-                self, 
-                files, 
-                cuts, 
-                out_dir, 
-                out_prefix, 
-                overwrite,  
-                x_min, 
-                x_max, 
+                self,
+                files,
+                cuts,
+                out_dir,
+                out_prefix,
+                overwrite,
+                x_min,
+                x_max,
                 y_min,
-                y_max, 
-                x_nbins, 
+                y_max,
+                x_nbins,
                 y_nbins,
                 e_min,
                 e_max,
                 e_nbins
-                ) -> None:  
-        
+                ) -> None:
+
         """
         Function initializing a processing object.
-        
+
         Parameters
         ----------
         files : list
@@ -134,116 +137,120 @@ class BkgMakerBase:
             Maximum energy edge of the bkg maps.
         e_nbins : int
             Number of bins along the energy axis
-            
+
          Returns
         -------
         out
             processing object
-        """        
-        
+        """
+
         self.files          = glob.glob(files)
         self.runs           = tuple(
                                 filter(
-                                    lambda r: r.obs_id is not None, 
-                                    [RunSummary(fname) for fname in 
+                                    lambda r: r.obs_id is not None,
+                                    [RunSummary(fname) for fname in
                                     self.files]
                                     )
                                 )
         self.cuts           = cuts
-        
+
         self.out_dir        = out_dir
-        self.out_prefix     = out_prefix 
+        self.out_prefix     = out_prefix
         self.overwrite      = overwrite
-        
+
         self.x_edges        = numpy.linspace(
-                                x_min,  
-                                x_max, 
+                                x_min,
+                                x_max,
                                 x_nbins+1
                                 )
-        
+
         self.y_edges        = numpy.linspace(
-                                y_min,  
-                                y_max, 
+                                y_min,
+                                y_max,
                                 y_nbins+1
                                 )
-        
+
         self.e_edges        = numpy.geomspace(
-                                e_min, 
-                                e_max, 
+                                e_min,
+                                e_max,
                                 e_nbins+1
-                                ) 
-        
-        self._bkg_maps   = {}   
-        
-        self.__bkg_map_maker = BaseMap()
-        
-        
+                                )
+
+        self._bkg_maps   = {}
+
+        self.__bkg_map_maker = None
+
+
     @property
     def bkg_map_maker(self):
-        print("This class uses the background method:", 
+        """Getter for bkg_map_maker."""
+        print("This class uses the background method:",
               self.__bkg_map_maker.__class__.__name__)
         return self.__bkg_map_maker
-    
+
     @bkg_map_maker.setter
     def bkg_map_maker(self, value):
+        """Setter for bkg_map_maker."""
         self.__bkg_map_maker = value
-        
+
     @property
     def bkg_maps(self):
+        """Getter for bkg_maps."""
         return self._bkg_maps
-        
+
     @classmethod
     def from_config_file(cls, config):
         """
         Function initializing a prozessing object from an input dictionary.
-        
+
         Parameters
         ----------
         config : dict
             dictionary containing the settings read from the yaml configuration
             file.
-            
+
         Raises
         ------
         ValueError
             Error is raised if no input dictionary is provided.
-        """ 
-        
+        """
+
         if config is None:
             raise ValueError(
                 "No configuration file provided."
             )
-        
+
         # obtain the parameters of the class on runtime; not know apriori
         class_params = inspect.signature(cls).parameters
-        
+
         params_for_init = {}
-        
+
         # Fill dictionary of parameters required by the corresponding class
         # with the values from the config file dictionary
         for current_par in class_params:
-            
+
             # read required class parameters from the config file dictionary
             try:
                 current_par_val = reduce(
-                    getitem, 
-                    config_class_map["{}".format(current_par)], 
+                    getitem,
+                    config_class_map[f"{current_par}"],
                     config
                     )
-            
+
                 if current_par in quantity_list:
                     current_par_val = u.Quantity(current_par_val)
                 else:
                     pass
-            
+
             except KeyError:
                 print(
-                    "Parameter {} missing in config file.".format(config_class_map["{}".format(current_par)])
+                    f"Parameter {config_class_map[f'{current_par}']} missing in config file."
                     )
-             
-            # assign the extracted parameter to the dictionary from which the class object will be created   
-            params_for_init["{}".format(current_par)] = current_par_val
-        
+
+            # assign the extracted parameter to the dictionary from which the
+            # class object will be created
+            params_for_init[f"{current_par}"] = current_par_val
+
         return cls(**params_for_init)
 
     def generate_runwise_maps(self) -> dict:
@@ -255,93 +262,95 @@ class BkgMakerBase:
         -------
         dict
             {'maps', 'outnames'}
-        """        
-        maps = {}  
-        
+        """
+        maps = {}
+
         with progressbar.ProgressBar(max_value=len(self.runs)) as progress:
-            for ri, run in enumerate(self.runs):
-                
+            for run_idx, run in enumerate(self.runs):
+
                 # Here the corrsponding bkg reconstruction algorith is applied
                 # to obtain the runwise bkg map
                 bkg_map = self.__bkg_map_maker.get_runwise_bkg(target_run = run)
-                
+
                 # get corresponding names for the bkg maps under which they can
                 # be safed
                 base_name = os.path.basename(run.file_name)
                 base_name, _ = os.path.splitext(base_name)
-                
+
                 output_name = os.path.join(
                                         self.out_dir,
                                         f"{self.out_prefix}{base_name}.fits"
                                         )
-                
-                maps['{}'.format(output_name)] = bkg_map
-                  
-                progress.update(ri)
-        
+
+                maps[f'{output_name}'] = bkg_map
+
+                progress.update(run_idx)
+
         self._bkg_maps = maps
-        
+
         return maps
-    
+
     @staticmethod
     def stack_maps(bkg_maps, x_edges, y_edges, e_edges) -> RectangularCameraImage:
         """
         Returns a stacked bkg map of all the runs.
-        
+
         Parameters
         ----------
         bkg_maps : dict
             Dictionary containing the bkg maps and output names for each run.
-        
+
         x_edges : numpy.ndarray
             Array of the bin edges along the x/azimuth axis; linear binning.
-        
+
         y_edges : numpy.ndarray
             Array of the bin edges along the y/Zenith axis; linear binning.
-        
+
         e_edges : numpy.ndarray
-            Array of the bin edges in energy; logarithmic binning.  
-        
+            Array of the bin edges in energy; logarithmic binning.
+
         Returns
         -------
         RectangularCameraImage
-        """        
+        """
         counts = numpy.sum([m.counts for m in bkg_maps.values()],
                            axis=0)
         exposure = u.Quantity([m.exposure for m in bkg_maps.values()]
                               ).sum(axis=0)
-        stacked_map = RectangularCameraImage(counts, 
-                                             x_edges, 
-                                             y_edges, 
-                                             e_edges, 
+        stacked_map = RectangularCameraImage(counts,
+                                             x_edges,
+                                             y_edges,
+                                             e_edges,
                                              exposure=exposure)
         return stacked_map
-        
+
     @staticmethod
     def write_maps(bkg_maps, overwrite) -> None:
         """
         This method writes the generated bkgmaps to the corresponding output
-        path. The output follows the definition in 
+        path. The output follows the definition in
         https://gamma-astro-data-formats.readthedocs.io/
-        
+
         Parameters
         ----------
         bkg_maps : dict
             Dictionary containing the bkg maps and output names for each run.
-        
+
         overwrite:  bool
             Whether to overwrite existing output files of same name.
-        """        
-                                           
+        """
+
         for key in bkg_maps.keys():
-            bkg_maps[key].to_hdu().writeto(key, overwrite=overwrite)    
+            bkg_maps[key].to_hdu().writeto(key, overwrite=overwrite)
 
 class Runwise(BkgMakerBase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-    
+    """
+    Class defining common functions for the runwise processing classes.
+    Not intended for direct usage.
+    """
+
     def get_maps(self):
-        """ Method for generating and saving runwise background maps to the 
+        """ Method for generating and saving runwise background maps to the
         output file.
 
         Returns
@@ -349,17 +358,19 @@ class Runwise(BkgMakerBase):
        bkg_maps : dict
             Dictionary containing the bkg maps and output names for each run.
         """
-        
+
         self.generate_runwise_maps()
         self.write_maps(bkg_maps=self.bkg_maps, overwrite=self.overwrite)
         return self.bkg_maps
 
 class Stacked(BkgMakerBase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-    
+    """
+    Class defining common functions for the stacked processing classes.
+    Not intended for direct usage.
+    """
+
     def get_maps(self):
-        """ Method for generating and saving stacked background maps to the 
+        """ Method for generating and saving stacked background maps to the
         output file.
 
         Returns
@@ -367,24 +378,28 @@ class Stacked(BkgMakerBase):
         bkg_maps : dict
             Dictionary containing the stacked bkg map and output name.
         """
-        
+
         self.generate_runwise_maps()
-        stacked_map = self.stack_maps()
-        
+        stacked_map = self.stack_maps(self.bkg_maps,
+                                      self.x_edges,
+                                      self.y_edges,
+                                      self.e_edges
+                                      )
+
         stacked_name = os.path.join(
                 self.out_dir,
                 f"{self.out_prefix}stacked_bkg_map.fits"
-                )   
+                )
         self.bkg_maps = {stacked_name: stacked_map}
         self.write_maps(bkg_maps=self.bkg_maps, overwrite=self.overwrite)
         return self.bkg_maps
-    
+
 class RunwiseWobbleMap(Runwise):
-    """ 
-    A class used to store the settings from the configuation file and to 
+    """
+    A class used to store the settings from the configuation file and to
     facilitate the generation of runwise background maps using the wobble
     background method.
-    
+
     Attributes
     ----------
     files : list
@@ -400,36 +415,36 @@ class RunwiseWobbleMap(Runwise):
     overwrite:  bool
         Whether to overwrite existing output files of same name.
     time_delta : astropy.units.quantity.Quantity
-        Time difference between runs for the run matching. 
+        Time difference between runs for the run matching.
     pointing_delta : astropy.units.quantity.Quantity
-        Pointing difference between runs for run matching.   
+        Pointing difference between runs for run matching.
     x_edges : numpy.ndarray
         Array of the bin edges along the x/azimuth axis; linear binning.
     y_edges : numpy.ndarray
         Array of the bin edges along the y/Zenith axis; linear binning.
     e_edges : numpy.ndarray
-        Array of the bin edges in energy; logarithmic binning.  
-    bkg_maps : dict 
+        Array of the bin edges in energy; logarithmic binning.
+    bkg_maps : dict
         Dictionary containing the generated bkg maps and output names for each
         run.
     bkg_map_maker : class
         Class of the background reconstruction algorithm used to obtain the
         runwise background maps.
-    """     
-    
-    def __init__(self, 
-                files, 
-                cuts, 
-                out_dir, 
-                out_prefix, 
-                overwrite, 
-                time_delta, 
-                pointing_delta, 
-                x_min, 
-                x_max, 
+    """
+
+    def __init__(self,
+                files,
+                cuts,
+                out_dir,
+                out_prefix,
+                overwrite,
+                time_delta,
+                pointing_delta,
+                x_min,
+                x_max,
                 y_min,
-                y_max, 
-                x_nbins, 
+                y_max,
+                x_nbins,
                 y_nbins,
                 e_min,
                 e_max,
@@ -468,28 +483,27 @@ class RunwiseWobbleMap(Runwise):
         e_nbins : int
             Number of bins along the energy axis
         time_delta : astropy.units.quantity.Quantity
-            Time difference between runs for the run matching. 
+            Time difference between runs for the run matching.
         pointing_delta : astropy.units.quantity.Quantity
-            Pointing difference between runs for run matching. 
+            Pointing difference between runs for run matching.
         """
-        
-        super().__init__(self, 
-                files = files,
-                cuts = cuts, 
-                out_dir = out_dir, 
-                out_prefix = out_prefix, 
-                overwrite = overwrite,  
-                x_min = x_min, 
-                x_max = x_max, 
-                y_min = y_min,
-                y_max = y_max, 
-                x_nbins = x_nbins, 
-                y_nbins = y_nbins,
-                e_min = e_min,
-                e_max = e_max,
-                e_nbins = e_nbins
-            
-        )
+
+        super().__init__(files,
+                        cuts,
+                        out_dir,
+                        out_prefix,
+                        overwrite,
+                        x_min,
+                        x_max,
+                        y_min,
+                        y_max,
+                        x_nbins,
+                        y_nbins,
+                        e_min,
+                        e_max,
+                        e_nbins
+                        )
+
         self.pointing_delta = pointing_delta
         self.time_delta     = time_delta
         self.bkg_map_maker = WobbleMap(runs=self.runs,
@@ -505,14 +519,14 @@ class RunwiseWobbleMap(Runwise):
     def bkg_map_maker(self, maker):
         if not isinstance(maker, WobbleMap):
             raise TypeError(f"Maker must be of type {WobbleMap}")
-        BkgMakerBase.bkg_map_maker.fset(maker)
+        BkgMakerBase.bkg_map_maker  = maker
 
 class StackedWobbleMap(Stacked):
-    """ 
-    A class used to store the settings from the configuation file and to 
+    """
+    A class used to store the settings from the configuation file and to
     facilitate the generation of a stacked background map using the wobble
     background method.
-    
+
     Attributes
     ----------
     files : list
@@ -528,36 +542,36 @@ class StackedWobbleMap(Stacked):
     overwrite:  bool
         Whether to overwrite existing output files of same name.
     time_delta : astropy.units.quantity.Quantity
-        Time difference between runs for the run matching. 
+        Time difference between runs for the run matching.
     pointing_delta : astropy.units.quantity.Quantity
-        Pointing difference between runs for run matching.   
+        Pointing difference between runs for run matching.
     x_edges : numpy.ndarray
         Array of the bin edges along the x/azimuth axis; linear binning.
     y_edges : numpy.ndarray
         Array of the bin edges along the y/Zenith axis; linear binning.
     e_edges : numpy.ndarray
-        Array of the bin edges in energy; logarithmic binning.  
-    bkg_maps : dict 
+        Array of the bin edges in energy; logarithmic binning.
+    bkg_maps : dict
         Dictionary containing the generated bkg maps and output names for each
         run.
     bkg_map_maker : class
         Class of the background reconstruction algorithm used to obtain the
         runwise background maps.
-    """    
-    
-    def __init__(self, 
-                files, 
-                cuts, 
-                out_dir, 
-                out_prefix, 
-                overwrite, 
-                time_delta, 
-                pointing_delta, 
-                x_min, 
-                x_max, 
+    """
+
+    def __init__(self,
+                files,
+                cuts,
+                out_dir,
+                out_prefix,
+                overwrite,
+                time_delta,
+                pointing_delta,
+                x_min,
+                x_max,
                 y_min,
-                y_max, 
-                x_nbins, 
+                y_max,
+                x_nbins,
                 y_nbins,
                 e_min,
                 e_max,
@@ -596,28 +610,26 @@ class StackedWobbleMap(Stacked):
         e_nbins : int
             Number of bins along the energy axis
         time_delta : astropy.units.quantity.Quantity
-            Time difference between runs for the run matching. 
+            Time difference between runs for the run matching.
         pointing_delta : astropy.units.quantity.Quantity
-            Pointing difference between runs for run matching. 
+            Pointing difference between runs for run matching.
         """
-        
-        super().__init__(self, 
-                files = files,
-                cuts = cuts, 
-                out_dir = out_dir, 
-                out_prefix = out_prefix, 
-                overwrite = overwrite,  
-                x_min = x_min, 
-                x_max = x_max, 
-                y_min = y_min,
-                y_max = y_max, 
-                x_nbins = x_nbins, 
-                y_nbins = y_nbins,
-                e_min = e_min,
-                e_max = e_max,
-                e_nbins = e_nbins
-            
-        )
+
+        super().__init__(files,
+                        cuts,
+                        out_dir,
+                        out_prefix,
+                        overwrite,
+                        x_min,
+                        x_max,
+                        y_min,
+                        y_max,
+                        x_nbins,
+                        y_nbins,
+                        e_min,
+                        e_max,
+                        e_nbins
+                        )
         self.pointing_delta = pointing_delta
         self.time_delta     = time_delta
         self.bkg_map_maker  = WobbleMap(runs=self.runs,
@@ -633,14 +645,14 @@ class StackedWobbleMap(Stacked):
     def bkg_map_maker(self, maker):
         if not isinstance(maker, WobbleMap):
             raise TypeError(f"Maker must be of type {WobbleMap}")
-        BkgMakerBase.bkg_map_maker.fset(maker)
+        BkgMakerBase.bkg_map_maker = maker
 
 class RunwiseExclusionMap(Runwise):
-    """ 
-    A class used to store the settings from the configuation file and to 
+    """
+    A class used to store the settings from the configuation file and to
     facilitate the generation of runwise background maps using the exclusion
     map method.
-    
+
     Attributes
     ----------
     files : list
@@ -656,16 +668,16 @@ class RunwiseExclusionMap(Runwise):
     overwrite:  bool
         Whether to overwrite existing output files of same name.
     time_delta : astropy.units.quantity.Quantity
-        Time difference between runs for the run matching. 
+        Time difference between runs for the run matching.
     pointing_delta : astropy.units.quantity.Quantity
-        Pointing difference between runs for run matching.   
+        Pointing difference between runs for run matching.
     x_edges : numpy.ndarray
         Array of the bin edges along the x/azimuth axis; linear binning.
     y_edges : numpy.ndarray
         Array of the bin edges along the y/Zenith axis; linear binning.
     e_edges : numpy.ndarray
-        Array of the bin edges in energy; logarithmic binning.  
-    bkg_maps : dict 
+        Array of the bin edges in energy; logarithmic binning.
+    bkg_maps : dict
         Dictionary containing the generated bkg maps and output names for each
         run.
     bkg_map_maker : class
@@ -673,22 +685,23 @@ class RunwiseExclusionMap(Runwise):
         runwise background maps.
     excl_region : list
         List of regions to be excluded from the background map in ds9
-        format. 
-    """    
-    
-    def __init__(self, 
-                files, 
-                cuts, 
-                out_dir, 
-                out_prefix, 
-                overwrite, 
-                time_delta, 
-                pointing_delta, 
-                x_min, 
-                x_max, 
+        format.
+    """
+
+    def __init__(self,
+                files,
+                cuts,
+                out_dir,
+                out_prefix,
+                overwrite,
+                time_delta,
+                pointing_delta,
+                excl_region,
+                x_min,
+                x_max,
                 y_min,
-                y_max, 
-                x_nbins, 
+                y_max,
+                x_nbins,
                 y_nbins,
                 e_min,
                 e_max,
@@ -727,34 +740,32 @@ class RunwiseExclusionMap(Runwise):
         e_nbins : int
             Number of bins along the energy axis
         time_delta : astropy.units.quantity.Quantity
-            Time difference between runs for the run matching. 
+            Time difference between runs for the run matching.
         pointing_delta : astropy.units.quantity.Quantity
-            Pointing difference between runs for run matching. 
+            Pointing difference between runs for run matching.
         excl_region : list
             List of regions to be excluded from the background map in ds9
-            format.  
+            format.
         """
-        
-        super().__init__(self, 
-                files = files,
-                cuts = cuts, 
-                out_dir = out_dir, 
-                out_prefix = out_prefix, 
-                overwrite = overwrite,  
-                x_min = x_min, 
-                x_max = x_max, 
-                y_min = y_min,
-                y_max = y_max, 
-                x_nbins = x_nbins, 
-                y_nbins = y_nbins,
-                e_min = e_min,
-                e_max = e_max,
-                e_nbins = e_nbins
-            
-        )
+
+        super().__init__(files,
+                        cuts,
+                        out_dir,
+                        out_prefix,
+                        overwrite,
+                        x_min,
+                        x_max,
+                        y_min,
+                        y_max,
+                        x_nbins,
+                        y_nbins,
+                        e_min,
+                        e_max,
+                        e_nbins
+                        )
         self.pointing_delta = pointing_delta
         self.time_delta     = time_delta
-        self.excl_region    = [Regions.parse(reg,format='ds9') for reg in 
+        self.excl_region    = [Regions.parse(reg,format='ds9') for reg in
                                excl_region]
         self.bkg_map_maker  = ExclusionMap(runs=self.runs,
                                            x_edges=self.x_edges,
@@ -765,19 +776,19 @@ class RunwiseExclusionMap(Runwise):
                                            time_delta=self.time_delta,
                                            pointing_delta=self.pointing_delta
                                            )
-    
+
     @BkgMakerBase.bkg_map_maker.setter
     def bkg_map_maker(self, maker):
         if not isinstance(maker, ExclusionMap):
             raise TypeError(f"Maker must be of type {ExclusionMap}")
-        BkgMakerBase.bkg_map_maker.fset(maker)
+        BkgMakerBase.bkg_map_maker = maker
 
 class StackedExclusionMap(Stacked):
-    """ 
-    A class used to store the settings from the configuation file and to 
+    """
+    A class used to store the settings from the configuation file and to
     facilitate the generation of a stacked background map using the exclusion
     map method.
-    
+
     Attributes
     ----------
     files : list
@@ -793,16 +804,16 @@ class StackedExclusionMap(Stacked):
     overwrite:  bool
         Whether to overwrite existing output files of same name.
     time_delta : astropy.units.quantity.Quantity
-        Time difference between runs for the run matching. 
+        Time difference between runs for the run matching.
     pointing_delta : astropy.units.quantity.Quantity
-        Pointing difference between runs for run matching.   
+        Pointing difference between runs for run matching.
     x_edges : numpy.ndarray
         Array of the bin edges along the x/azimuth axis; linear binning.
     y_edges : numpy.ndarray
         Array of the bin edges along the y/Zenith axis; linear binning.
     e_edges : numpy.ndarray
-        Array of the bin edges in energy; logarithmic binning.  
-    bkg_maps : dict 
+        Array of the bin edges in energy; logarithmic binning.
+    bkg_maps : dict
         Dictionary containing the generated bkg maps and output names for each
         run.
     bkg_map_maker : class
@@ -810,22 +821,23 @@ class StackedExclusionMap(Stacked):
         runwise background maps.
     excl_region : list
         List of regions to be excluded from the background map in ds9
-        format. 
-    """    
-    
-    def __init__(self, 
-                files, 
-                cuts, 
-                out_dir, 
-                out_prefix, 
-                overwrite, 
-                time_delta, 
-                pointing_delta, 
-                x_min, 
-                x_max, 
+        format.
+    """
+
+    def __init__(self,
+                files,
+                cuts,
+                out_dir,
+                out_prefix,
+                overwrite,
+                time_delta,
+                pointing_delta,
+                excl_region,
+                x_min,
+                x_max,
                 y_min,
-                y_max, 
-                x_nbins, 
+                y_max,
+                x_nbins,
                 y_nbins,
                 e_min,
                 e_max,
@@ -864,34 +876,32 @@ class StackedExclusionMap(Stacked):
         e_nbins : int
             Number of bins along the energy axis
         time_delta : astropy.units.quantity.Quantity
-            Time difference between runs for the run matching. 
+            Time difference between runs for the run matching.
         pointing_delta : astropy.units.quantity.Quantity
-            Pointing difference between runs for run matching. 
+            Pointing difference between runs for run matching.
         excl_region : list
             List of regions to be excluded from the background map in ds9
-            format. 
+            format.
         """
-        
-        super().__init__(self, 
-                files = files,
-                cuts = cuts, 
-                out_dir = out_dir, 
-                out_prefix = out_prefix, 
-                overwrite = overwrite,  
-                x_min = x_min, 
-                x_max = x_max, 
-                y_min = y_min,
-                y_max = y_max, 
-                x_nbins = x_nbins, 
-                y_nbins = y_nbins,
-                e_min = e_min,
-                e_max = e_max,
-                e_nbins = e_nbins
-            
-        )
+
+        super().__init__(files,
+                        cuts,
+                        out_dir,
+                        out_prefix,
+                        overwrite,
+                        x_min,
+                        x_max,
+                        y_min,
+                        y_max,
+                        x_nbins,
+                        y_nbins,
+                        e_min,
+                        e_max,
+                        e_nbins
+                        )
         self.pointing_delta = pointing_delta
         self.time_delta     = time_delta
-        self.excl_region    = [Regions.parse(reg,format='ds9') for reg in 
+        self.excl_region    = [Regions.parse(reg,format='ds9') for reg in
                                excl_region]
         self.bkg_map_maker  = ExclusionMap(runs=self.runs,
                                            x_edges=self.x_edges,
@@ -907,4 +917,4 @@ class StackedExclusionMap(Stacked):
     def bkg_map_maker(self, maker):
         if not isinstance(maker, ExclusionMap):
             raise TypeError(f"Maker must be of type {ExclusionMap}")
-        BkgMakerBase.bkg_map_maker.fset(maker)
+        BkgMakerBase.bkg_map_maker = maker

--- a/src/pybkgmodel/processing.py
+++ b/src/pybkgmodel/processing.py
@@ -231,7 +231,7 @@ class _BkgMakerBase:
             
             except KeyError:
                 print(
-                    "Parameter {} missing in config file.".format(current_par)
+                    "Parameter {} missing in config file.".format(config_class_map["{}".format(current_par)])
                     )
                 
             params_for_init["{}".format(current_par)] = current_par_val

--- a/src/pybkgmodel/scripts/bkgmodel.py
+++ b/src/pybkgmodel/scripts/bkgmodel.py
@@ -36,17 +36,17 @@ def main():
 
     message(f'Generating background maps')
     if config['mode'] == 'runwise_wobble':
-        process_module = RunwiseWobbleMap.from_config_file(config)
+        bkg_processor = RunwiseWobbleMap.from_config_file(config)
     elif config['mode'] == 'stacked_wobble':
-        process_module = StackedWobbleMap.from_config_file(config)
+        bkg_processor = StackedWobbleMap.from_config_file(config)
     elif config['mode'] == 'runwise_exclusion':
-        process_module = RunwiseExclusionMap.from_config_file(config)
+        bkg_processor = RunwiseExclusionMap.from_config_file(config)
     elif config['mode'] == 'stacked_exclusion':
-        process_module = StackedExclusionMap.from_config_file(config)
+        bkg_processor = StackedExclusionMap.from_config_file(config)
     else:
         ValueError(f"Unsupported mode '{config['mode']}'. This should have been caught earlier.")
 
-    process_module.get_maps()
+    bkg_processor.get_maps()
 
 if __name__ == "__main__":
     main()

--- a/src/pybkgmodel/scripts/bkgmodel.py
+++ b/src/pybkgmodel/scripts/bkgmodel.py
@@ -1,14 +1,20 @@
 #!/usr/bin/env python3
-import yaml
 import argparse
 
-# import regions
+import yaml
 
 from pybkgmodel.message import message
-from pybkgmodel.processing import RunwiseWobbleMap, StackedWobbleMap, RunwiseExclusionMap, StackedExclusionMap
+from pybkgmodel.processing import (RunwiseWobbleMap,
+                                   StackedWobbleMap,
+                                   RunwiseExclusionMap,
+                                   StackedExclusionMap
+                                    )
 
 
 def main():
+    """
+    Function running the entire background reconstruction procedure.
+    """
     arg_parser = argparse.ArgumentParser(
         description="""
         IACT background generation tool
@@ -16,25 +22,26 @@ def main():
     )
 
     arg_parser.add_argument(
-        "--config", 
+        "--config",
         default="config.yaml",
         help='Configuration file to steer the code execution.'
     )
     parsed_args = arg_parser.parse_args()
 
     config = yaml.load(open(parsed_args.config, "r"), Loader=yaml.SafeLoader)
-    
+
     supported_modes = (
         'runwise_exclusion',
         'runwise_wobble',
         'stacked_exclusion',
         'stacked_wobble',
     )
-    
-    if config['mode'] not in supported_modes:
-        raise ValueError(f"Unsupported mode '{config['mode']}', valid choices are '{supported_modes}'")
 
-    message(f'Generating background maps')
+    if config['mode'] not in supported_modes:
+        raise ValueError(f"Unsupported mode '{config['mode']}',\
+                         valid choices are '{supported_modes}'")
+
+    message('Generating background maps')
     if config['mode'] == 'runwise_wobble':
         bkg_processor = RunwiseWobbleMap.from_config_file(config)
     elif config['mode'] == 'stacked_wobble':
@@ -44,7 +51,8 @@ def main():
     elif config['mode'] == 'stacked_exclusion':
         bkg_processor = StackedExclusionMap.from_config_file(config)
     else:
-        ValueError(f"Unsupported mode '{config['mode']}'. This should have been caught earlier.")
+        raise ValueError(f"Unsupported mode '{config['mode']}'. \
+                         This should have been caught earlier.")
 
     bkg_processor.get_maps()
 

--- a/src/pybkgmodel/scripts/bkgmodel.py
+++ b/src/pybkgmodel/scripts/bkgmodel.py
@@ -5,7 +5,7 @@ import argparse
 # import regions
 
 from pybkgmodel.message import message
-from pybkgmodel.processing import process_runwise_wobble_map, process_stacked_wobble_map, process_runwise_exclusion_map, process_stacked_exclusion_map
+from pybkgmodel.processing import RunwiseWobbleMap, StackedWobbleMap, RunwiseExclusionMap, StackedExclusionMap
 
 
 def main():
@@ -36,16 +36,17 @@ def main():
 
     message(f'Generating background maps')
     if config['mode'] == 'runwise_wobble':
-        process_runwise_wobble_map(config)
+        process_module = RunwiseWobbleMap.from_config_file(config)
     elif config['mode'] == 'stacked_wobble':
-        process_stacked_wobble_map(config)
+        process_module = StackedWobbleMap.from_config_file(config)
     elif config['mode'] == 'runwise_exclusion':
-        process_runwise_exclusion_map(config)
+        process_module = RunwiseExclusionMap.from_config_file(config)
     elif config['mode'] == 'stacked_exclusion':
-        process_stacked_exclusion_map(config)
+        process_module = StackedExclusionMap.from_config_file(config)
     else:
         ValueError(f"Unsupported mode '{config['mode']}'. This should have been caught earlier.")
 
+    process_module.get_maps()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Aim: minimize duplicated code when introducing new bkg reconstruction methods

Done:
- changed the processing module from procedual routines to classes (processing.py)

- also moved the background reconstruction methods to classes (model.py)

- adapted the config file and the main module to work with the introduced classes (config_example.yaml, bkgmodel.py)

- tested the functionality of the code on MAGIC data; not tested with LST data yet, but since the classes loading the data remain untouched, the changes should also work for LST data

Todo:
- add docstrings to all classes and functions

- validate functions with LST data