### PR TITLE
First version of the documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Tests
         run: |
-          pytest --cov=pybkgmodel --cov-report=xml
+          pytest --cov=src/pybkgmodel --cov-report=xml
 
-      - uses: codecov/codecov-action@v1
+      - name: Codecov
+        uses: codecov/codecov-action@v3.1.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,37 @@ jobs:
 
       - name: Codecov
         uses: codecov/codecov-action@v3.1.4
+        
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install doc dependencies
+        run: |
+          sudo apt update --yes && sudo apt install --yes git build-essential
+          pip install -U pip setuptools wheel
+          pip install -e .[docs]
+          git describe --tags
+          python -c 'import pybkgmodel; print(pybkgmodel.__version__)'
+
+      - name: Build docs
+        run: cd docs && make html
+
+      - name: Deploy to gihub pages
+        # only run on push to main
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: docs/build/html
+          CLEAN: true
+          SINGLE_COMMIT: true

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/source/api/
 
 # PyBuilder
 target/

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,7 @@
+Ievgen Vovk <vovk@icrr.u-tokyo.ac.jp>
+Marcel Strzys <m.strzys@live.de> Marcel Strzys <mstrzys@protonmail.com>
+Maximilian Linhoff <maximilian.linhoff@tu-dortmund.de> Maximilian Nöthe <maximilian.noethe@tu-dortmund.de>
+Moritz Hütten <huetten@icrr.u-tokyo.ac.jp>
+Simone Mender <simone.mender@googlemail.com>
+Michele Peresano <peresano.michele@gmail.com> Michele Peresano <michele.peresano@cea.fr>
+Michele Peresano <peresano.michele@gmail.com> Michele Peresano <michele.peresano@to.infn.it>

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
 # pybkgmodel
 
-## Description
+[![CI](https://github.com/cta-observatory/pybkgmodel/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/cta-observatory/pybkgmodel/actions/workflows/ci.yml)
+
+[![coverage](https://codecov.io/gh/cta-observatory/pybkgmodel/branch/main/graph/badge.svg?token=WsJUEfyBsv)](https://codecov.io/gh/cta-observatory/pybkgmodel)
+
 Background model generation tool for Imaging Atmospheric Cherenkov Telescopes (IACTs). Constructs background from the available data excluding the region of interest from the process. 
 
-Supported background generation methods: 
+Supported **background generation methods**: 
 
- - "wobble map" - assumes IACT observations were performed wobbling around the target position. For each telescope pointing, the background is generated from the IACT camera half, that does not include the source position;
+ - "wobble map" - assumes IACT observations were performed wobbling around the target position. For each telescope pointing, the background is generated from the IACT camera half, which does not include the source position;
  - "exclusion map" - excludes the specified sky region from consideration and generates the background model from the remaining data.
  
-Supported background generation modes:
+Supported **background generation modes**:
 
  - "run-wise": for each telescope "data run" (observation session unit) identifies other runs close to it in time and constructs the individual background model from them only;
- - "stacked": add the "run-wise" models together, resulting in an observation-averaged background model. The latter is in general less noisy than the individual "run-wise" models at the cost of loosing information on the potential background variation during the observations.
+ - "stacked": add the "run-wise" models together, resulting in an observation-averaged background model. The latter is in general less noisy than the individual "run-wise" models at the cost of losing information on the potential background variation during the observations.
 
 ## Installation
+
 Clone and install with `pip`:
 
 ```
@@ -23,7 +27,8 @@ pip install .
 ```
 
 ## Usage
-The background model generation is controlled via a configuration file in the YAML format (an example may be found in the "examples" folder). It specifies the input data, output folder, background model generation method, maps binning and exclusion regions to apply.
+
+The background model generation is controlled via a configuration file in the YAML format (an example may be found in the "examples" folder). It specifies the input data, output folder, background model generation method, maps' binning and exclusion regions to apply.
 
 Execute `bkgmodel` to run the code, specifying the corresponding configuration file, e.g.:
 
@@ -33,16 +38,21 @@ bkgmodel --config examples/config_example.yaml
 
 
 ## Support
+
 Please use [issues](https://gitlab.pic.es/mstrzys/pybkgmodel/issues) to report problems or make suggestions.
 
 ## Roadmap
+
 Despite the initial focus on CTA/LST and MAGIC data, the project may be extended to any other IACTs (e.g. other CTA instruments).
 
 ## Contributing
+
 Contributions are welcome.
 
 ## Authors and acknowledgment
+
 Original developers are Marcel Strzys, Ievgen Vovk and Moritz Huetten.
 
 ## Project status
-Active development, so major changes are possible without a notice.
+
+Active development, so major changes are possible without notice.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,24 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?= -W --keep-going -n --color
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: all help clean Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+clean:
+	rm -rf api
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/authors.rst
+++ b/docs/source/authors.rst
@@ -1,0 +1,16 @@
+.. _authors:
+
+Authors
+=======
+
+The main authors are Marcel Strzys, Ievgen Vovk and Moritz Huetten.
+
+Please visit the
+`GitHub contributors page <https://github.com/cta-observatory/pybkgmodel/graphs/contributors>`_
+or run
+
+.. code-block:: bash
+
+    git shortlog -sne --no-merges
+
+to see the full list of contributors.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,65 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "pybkgmodel"
+copyright = "2023, Marcel Strzys, Ievgen Vovk, Moritz Huetten"
+author = "Marcel Strzys, Ievgen Vovk, Moritz Huetten"
+release = "v0.0.0"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx_automodapi.automodapi",
+    "sphinxarg.ext",
+    "sphinx_copybutton",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx.ext.coverage",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.mathjax",
+    "sphinx_automodapi.automodapi",
+    "sphinx_automodapi.smart_resolver",
+    "numpydoc",
+    "IPython.sphinxext.ipython_console_highlighting",
+]
+numpydoc_show_class_members = False
+automodapi_inheritance_diagram = False
+
+templates_path = ["_templates"]
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "furo"
+html_title = "Home"
+
+html_theme_options = {
+    "sidebar_hide_name": False,
+    "navigation_with_keys": True,
+    "footer_icons": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/cta-observatory/pybkgmodel",
+            "html": "",
+            "class": "fa-brands fa-solid fa-github fa-2x",
+        },
+    ],
+}
+
+html_static_path = ["_static"]
+
+html_css_files = [
+    "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/fontawesome.min.css",
+    "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/solid.min.css",
+    "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/brands.min.css",
+]

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -1,0 +1,6 @@
+.. _contribute:
+
+Contribute
+==========
+
+WIP

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,62 @@
+.. pybkgmodel documentation master file, created by
+   sphinx-quickstart on Fri Jul 14 11:55:41 2023.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+**pybkgmodel** documentation
+============================
+
+.. |ci| image:: https://github.com/cta-observatory/pybkgmodel/actions/workflows/ci.yml/badge.svg?branch=main
+  :target: https://github.com/cta-observatory/pybkgmodel/actions/workflows/ci.yml
+
+.. |coverage| image:: https://codecov.io/gh/cta-observatory/pybkgmodel/branch/main/graph/badge.svg
+  :target: https://codecov.io/gh/cta-observatory/pybkgmodel
+
+|ci| |coverage|
+
+.. _CTA: https://www.cta-observatory.org/
+.. _LST: https://www.cta-observatory.org/project/technology/lst/
+.. _MAGIC: https://magic.mpp.mpg.de/
+.. _pybkgmodel: https://github.com/cta-observatory/pybkgmodel
+
+.. warning::
+
+  The project is under active development, so major changes are possible without notice.
+
+  Please use
+  `issues <https://gitlab.pic.es/mstrzys/pybkgmodel/issues>`_
+  to report problems or make suggestions.
+
+`pybkgmodel`_ is a background model generation tool for Imaging Atmospheric Cherenkov Telescopes (IACTs).
+It allows building background maps from the available data excluding the region of interest from the process.
+
+Supported **background generation methods**:
+
+- "wobble map" - assumes IACT observations were performed wobbling around the target position. For each telescope pointing,
+  the background is generated from the IACT camera half, which does not include the source position;
+- "exclusion map" - excludes the specified sky region from consideration and generates the background model from the remaining data.
+
+Supported **background generation modes**:
+
+- "run-wise": for each telescope "data run" (observation session unit) identifies other runs close to it in time
+  and constructs the individual background model from them only;
+- "stacked": add the "run-wise" models together, resulting in an observation-averaged background model.
+
+The latter is in general less noisy than the individual "run-wise" models at the cost of losing information
+on the potential background variation during the observations.
+
+.. note::
+
+  Despite the initial focus on
+  `CTA`_/`LST`_ and `MAGIC`_ data,
+  the project may be extended to any other IACTs (e.g. other CTA instruments).
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+
+   install
+   userguide
+   reference
+   contribute
+   authors

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,0 +1,28 @@
+.. _install:
+
+Install
+=======
+
+.. _clone: https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository?tool=webui#cloning-a-repository
+
+Requirements
+------------
+
+- ``git``
+- ``python>=3.8``
+- ``pip``
+
+Is it recommended to work from a Python virtual environment
+created using e.g.
+`venv <https://docs.python.org/3/tutorial/venv.html#creating-virtual-environments>`_
+or
+`mamba <https://mamba.readthedocs.io/en/latest/>`_
+
+Developers
+----------
+
+1. `clone`_ the `repository <https://github.com/cta-observatory/pybkgmodel>`_
+2. (recommended) create a virtual environment
+3. install the package in editable mode with ``pip install -e '.[dev]'``
+
+

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -1,0 +1,35 @@
+.. _reference:
+
+=============
+Reference API
+=============
+
+🚧
+
+
+Command Line Interface
+======================
+
+.. _bkgmodel:
+
+bkgmodel
+--------
+
+.. argparse::
+   :module: pybkgmodel.scripts.bkgmodel
+   :func: arg_parser
+   :prog: bkgmodel
+
+Subpackages and modules
+=======================
+
+.. automodapi:: pybkgmodel.camera
+
+.. automodapi:: pybkgmodel.data
+
+.. automodapi:: pybkgmodel.message
+
+.. automodapi:: pybkgmodel.model
+
+.. automodapi:: pybkgmodel.processing
+   :include-all-objects:

--- a/docs/source/userguide.rst
+++ b/docs/source/userguide.rst
@@ -1,0 +1,27 @@
+.. _userguide:
+
+User Guide
+==========
+
+Generate a background model
+---------------------------
+
+The background model generation is controlled via a configuration file in YAML format (see :ref:`userguide-cfg`).
+
+Execute :ref:`bkgmodel` to run the code, specifying the corresponding configuration file, e.g.:
+
+.. code-block::
+
+    bkgmodel --config examples/config_example.yaml
+
+
+.. _userguide-cfg:
+
+Configuration
+-------------
+
+In the configuration file, it is possible to specify the input data,
+output folder, background model generation method, maps binning and exclusion regions to apply.
+
+.. literalinclude:: ../../examples/config_example.yaml
+   :language: yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,16 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-"tests" = [
-    "pytest",
-    "pytest-cov",
+"docs" = [
+    "furo",
+    "ipython",
+    "numpydoc",
+    "sphinx-argparse",
+    "sphinx-automodapi",
+    "sphinx-copybutton",
 ]
+"dev" = ["black", "ruff", "pybkgmodel[tests]", "pybkgmodel[docs]"]
+"tests" = ["pytest", "pytest-cov"]
 
 [project.urls]
 "Homepage" = "https://github.com/cta-observatory/pybkgmodel/-"

--- a/src/pybkgmodel/camera.py
+++ b/src/pybkgmodel/camera.py
@@ -9,6 +9,16 @@ from astropy.wcs import WCS
 from astropy.coordinates import SkyCoord, Angle
 from matplotlib import pyplot
 
+__all__ = [
+    "solid_angle_lat_lon_rectangle",
+    "cstat",
+    "pwl2counts",
+    "nodespec_integral",
+    "node_cnt_diff",
+    "CameraImage",
+    "RectangularCameraImage",
+]
+
 
 def solid_angle_lat_lon_rectangle(theta_E, theta_W, phi_N, phi_S):
     """

--- a/src/pybkgmodel/data.py
+++ b/src/pybkgmodel/data.py
@@ -8,6 +8,15 @@ import astropy.units as u
 
 from astropy.coordinates import SkyCoord, EarthLocation, AltAz
 
+__all__ = [
+    "find_run_neighbours",
+    "EventSample",
+    "EventFile",
+    "MagicEventFile",
+    "LstEventFile",
+    "RunSummary",
+]
+
 
 def find_run_neighbours(target_run, run_list, time_delta, pointing_delta):
     """

--- a/src/pybkgmodel/message.py
+++ b/src/pybkgmodel/message.py
@@ -1,5 +1,8 @@
 import datetime
 
+__all__ = ["timestamp", "message"]
+
+
 def timestamp(text):
     """
     This function returns the specified text with the prefix of the current date

--- a/src/pybkgmodel/model.py
+++ b/src/pybkgmodel/model.py
@@ -8,6 +8,8 @@ from pybkgmodel.data import find_run_neighbours
 
 from pybkgmodel.camera import RectangularCameraImage
 
+__all__ = ["BaseMap", "WobbleMap", "ExclusionMap"]
+
 
 class BaseMap:
 

--- a/src/pybkgmodel/processing.py
+++ b/src/pybkgmodel/processing.py
@@ -20,17 +20,19 @@ from pybkgmodel.model import (WobbleMap,
                             )
 from pybkgmodel.camera import RectangularCameraImage
 
-# list of class attributes, which have a unit assigned
+__all__ = [
+    "quantity_list",
+    "config_class_map",
+    "BkgMakerBase",
+    "Runwise",
+    "Stacked",
+    "RunwiseWobbleMap",
+    "StackedWobbleMap",
+    "RunwiseExclusionMap",
+    "StackedExclusionMap",
+]
 quantity_list = [
-                'time_delta',
-                'pointing_delta',
-                'x_min',
-                'x_max',
-                'y_min',
-                'y_max',
-                'e_min',
-                'e_max'
-                ]
+"""List of class attributes, which have a unit assigned."""
 
 # dictionary to map names in the config file to the class attribute names
 config_class_map = {
@@ -52,6 +54,8 @@ config_class_map = {
     'e_nbins' : ['binning', 'energy', 'nbins'],
     'excl_region' : ['exclusion_regions']
 }
+"""Dictionary to map names in the config file to the class attribute names."""
+
 
 class BkgMakerBase:
     """
@@ -78,7 +82,7 @@ class BkgMakerBase:
         Array of the bin edges along the y/Zenith axis; linear binning.
     e_edges : numpy.ndarray
         Array of the bin edges in energy; logarithmic binning.
-    bkg_maps : dict
+    _bkg_maps : dict
         Dictionary containing the generated bkg maps and output names for each
         run.
     bkg_map_maker : class
@@ -424,7 +428,7 @@ class RunwiseWobbleMap(Runwise):
         Array of the bin edges along the y/Zenith axis; linear binning.
     e_edges : numpy.ndarray
         Array of the bin edges in energy; logarithmic binning.
-    bkg_maps : dict
+    _bkg_maps : dict
         Dictionary containing the generated bkg maps and output names for each
         run.
     bkg_map_maker : class
@@ -551,7 +555,7 @@ class StackedWobbleMap(Stacked):
         Array of the bin edges along the y/Zenith axis; linear binning.
     e_edges : numpy.ndarray
         Array of the bin edges in energy; logarithmic binning.
-    bkg_maps : dict
+    _bkg_maps : dict
         Dictionary containing the generated bkg maps and output names for each
         run.
     bkg_map_maker : class
@@ -677,7 +681,7 @@ class RunwiseExclusionMap(Runwise):
         Array of the bin edges along the y/Zenith axis; linear binning.
     e_edges : numpy.ndarray
         Array of the bin edges in energy; logarithmic binning.
-    bkg_maps : dict
+    _bkg_maps : dict
         Dictionary containing the generated bkg maps and output names for each
         run.
     bkg_map_maker : class
@@ -813,7 +817,7 @@ class StackedExclusionMap(Stacked):
         Array of the bin edges along the y/Zenith axis; linear binning.
     e_edges : numpy.ndarray
         Array of the bin edges in energy; logarithmic binning.
-    bkg_maps : dict
+    _bkg_maps : dict
         Dictionary containing the generated bkg maps and output names for each
         run.
     bkg_map_maker : class

--- a/src/pybkgmodel/scripts/bkgmodel.py
+++ b/src/pybkgmodel/scripts/bkgmodel.py
@@ -4,11 +4,12 @@ import argparse
 import yaml
 
 from pybkgmodel.message import message
-from pybkgmodel.processing import (RunwiseWobbleMap,
-                                   StackedWobbleMap,
-                                   RunwiseExclusionMap,
-                                   StackedExclusionMap
-                                    )
+from pybkgmodel.processing import (
+    RunwiseWobbleMap,
+    StackedWobbleMap,
+    RunwiseExclusionMap,
+    StackedExclusionMap,
+)
 
 arg_parser = argparse.ArgumentParser(
     description="""
@@ -33,30 +34,35 @@ def main():
     config = yaml.load(open(parsed_args.config, "r"), Loader=yaml.SafeLoader)
 
     supported_modes = (
-        'runwise_exclusion',
-        'runwise_wobble',
-        'stacked_exclusion',
-        'stacked_wobble',
+        "runwise_exclusion",
+        "runwise_wobble",
+        "stacked_exclusion",
+        "stacked_wobble",
     )
 
-    if config['mode'] not in supported_modes:
-        raise ValueError(f"Unsupported mode '{config['mode']}',\
-                         valid choices are '{supported_modes}'")
+    if config["mode"] not in supported_modes:
+        raise ValueError(
+            f"Unsupported mode '{config['mode']}',\
+                         valid choices are '{supported_modes}'"
+        )
 
-    message('Generating background maps')
-    if config['mode'] == 'runwise_wobble':
+    message("Generating background maps")
+    if config["mode"] == "runwise_wobble":
         bkg_processor = RunwiseWobbleMap.from_config_file(config)
-    elif config['mode'] == 'stacked_wobble':
+    elif config["mode"] == "stacked_wobble":
         bkg_processor = StackedWobbleMap.from_config_file(config)
-    elif config['mode'] == 'runwise_exclusion':
+    elif config["mode"] == "runwise_exclusion":
         bkg_processor = RunwiseExclusionMap.from_config_file(config)
-    elif config['mode'] == 'stacked_exclusion':
+    elif config["mode"] == "stacked_exclusion":
         bkg_processor = StackedExclusionMap.from_config_file(config)
     else:
-        raise ValueError(f"Unsupported mode '{config['mode']}'. \
-                         This should have been caught earlier.")
+        raise ValueError(
+            f"Unsupported mode '{config['mode']}'. \
+                         This should have been caught earlier."
+        )
 
     bkg_processor.get_maps()
+
 
 if __name__ == "__main__":
     main()

--- a/src/pybkgmodel/scripts/bkgmodel.py
+++ b/src/pybkgmodel/scripts/bkgmodel.py
@@ -10,22 +10,24 @@ from pybkgmodel.processing import (RunwiseWobbleMap,
                                    StackedExclusionMap
                                     )
 
+arg_parser = argparse.ArgumentParser(
+    description="""
+        IACT background generation tool
+        """
+)
+
+arg_parser.add_argument(
+    "--config",
+    default="config.yaml",
+    help="Configuration file to steer the code execution.",
+)
+
 
 def main():
     """
     Function running the entire background reconstruction procedure.
     """
-    arg_parser = argparse.ArgumentParser(
-        description="""
-        IACT background generation tool
-        """
-    )
 
-    arg_parser.add_argument(
-        "--config",
-        default="config.yaml",
-        help='Configuration file to steer the code execution.'
-    )
     parsed_args = arg_parser.parse_args()
 
     config = yaml.load(open(parsed_args.config, "r"), Loader=yaml.SafeLoader)


### PR DESCRIPTION
This PR sets up the first version of the documentation based on [Sphinx](https://www.sphinx-doc.org/en/master/index.html).

#### Details about the docs

- added some new dependencies
- the contents reflect mostly what I found already there, since I didn't start using this project seriously
- the stylistic choices like the theme and the structure of the documentation are mostly based on my personal preference, they can be of course changed
- warnings are treated as errors as a conservative choice

#### Changes to other parts of the package

- added [.mailmap](https://git-scm.com/docs/gitmailmap) file
- the API members have been exposed for Sphinx to find
- the argument parser for the bkgmodel script has been made a global variable for [sphinx-argparse](https://sphinx-argparse.readthedocs.io/en/latest/index.html) 
- a small fix where a class attribute was private, but was described as public
- the test coverage job was saying 100%, but it's 1% - the reason was a wrong path given to pytest-cov 

#### Deployment

- the CI has been updated with a job to deploy on GitHub Pages (easy to activate from the repo's settings, but not easy to support multiple versions when the project starts to tag releases)
- there is a configuration file for [ReadTheDocs](https://readthedocs.org/), but the project needs to be activated there