### PR TITLE
Update dependencies versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,22 +13,22 @@ authors = [
 description = "Background model construction tool for Imaging Atmospheric Cherenkov telescopes"
 readme = "README.md"
 license = { file="LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: GNU GPLv3",
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "astropy==5.0.2",
-    "matplotlib==3.5.1",
-    "numpy==1.21.5",
-    "pandas==1.3.5",
-    "progressbar2==4.0.0",
-    "regions==0.5",
-    "scipy==1.8.0",
-    "uproot==4.2.3",
-    "PyYAML==5.3.1"
+    "astropy >=5.3,<7.0.0a0",
+    "matplotlib",
+    "numpy>=1.21.5,<2.0",
+    "pandas",
+    "progressbar2",
+    "regions",
+    "scipy",
+    "uproot",
+    "PyYAML"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
I recently had to re-install this package in a new environment and encountered some issues.

The very old pinned version of astropy was triggering a crash from setuptools which only triggered a cascade of more issues when trying to fix it.

All dependencies' versions were pinned and this leaves very small range to development: I propose here to pin only the core ones (_astropy_ and _numpy_ and leave thew rest to pip - or conda).
I also propose to bump the minimum version of Python from 3.8 to 3.9 as the former will reach end-of-life in about 4 months.

Also fixes #8.

Testing (see #16) should uncover any issue with these changes and only then it will make sense to pin versions.