### PR TITLE
Disable CI on pushes if not on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "**"
+  pull_request:
 
 env:
   MPLBACKEND: Agg


### PR DESCRIPTION
While working on #17 I noticed that the number of CI pipelines triggered each time is basically doubled because they were triggered on both push and pull request events regardless of the branch.

It makes sense to trigger a pipeline on push only on the main branch, since the pull request one will already cover pushed on the corresponding branch.